### PR TITLE
Fixed an issue of clearing Secure Boot enrollment

### DIFF
--- a/SetupDataPkg/ConfApp/SecureBoot.c
+++ b/SetupDataPkg/ConfApp/SecureBoot.c
@@ -165,7 +165,7 @@ PrintSBOptions (
   EnrollTextColor = SecureBootEnrollTemplate.DescriptionTextAttr;
   EnrollEndState  = SecureBootEnrollTemplate.EndState;
   ClearTextColor  = SecureBootClearTemplate.DescriptionTextAttr;
-  ClearEndState   = SecureBootEnrollTemplate.EndState;
+  ClearEndState   = SecureBootClearTemplate.EndState;
   if ((mCurrentState != MU_SB_CONFIG_NONE) && IsPostReadyToBoot ()) {
     gST->ConOut->SetAttribute (gST->ConOut, EFI_TEXT_ATTR (EFI_YELLOW, EFI_BLACK));
     Print (L"Post ready to boot, below options are view only:\n");


### PR DESCRIPTION
The original code incorrectly set the state machine to "enroll" when selecting the "None" option. This change fixed the issue and added a corresponding unit test case.