### PR TITLE
Fixed a Python tool issue introduced during cleaning

### DIFF
--- a/SetupDataPkg/Tools/GenCfgData.py
+++ b/SetupDataPkg/Tools/GenCfgData.py
@@ -449,7 +449,7 @@ class CFG_YAML():
                     raise Exception('Unexpected format at line: %s' % (curr_line))
 
                 level += 1
-                self.parse(parent_name, child, level)
+                self.parse(self.current_key, child, level)
                 level -= 1
 
                 line = self.peek_line()
@@ -476,6 +476,7 @@ class CFG_YAML():
             if pos > 0:
                 child = None
                 key = curr_line[start:pos].strip()
+                self.current_key = key
                 if curr_line[pos + 2] == '>':
                     curr[key] = curr_line[pos + 3:]
                 else:
@@ -512,6 +513,7 @@ class CFG_YAML():
             elif marker2 == ':':
                 child = OrderedDict()
                 key = curr_line[start:-1].strip()
+                self.current_key = key
                 if key == '$ACTION':
                     # special virtual nodes, rename to ensure unique key
                     key = '$ACTION_%04X' % self.index


### PR DESCRIPTION
This issue was introduced during cleaning the Python script for linting compliance. The original code will take the key from previous round of parsing, which will trip on the linting error. This change will set it to the global variable of this class instance to avoid linting violation or functional discontinuities.