### PR TITLE
Fixing a logic error when no FMP instance is installed

### DIFF
--- a/SetupDataPkg/ConfApp/SystemInfo.c
+++ b/SetupDataPkg/ConfApp/SystemInfo.c
@@ -89,7 +89,7 @@ PrintVersion (
   if (EFI_ERROR (Status) && (Status != EFI_NOT_FOUND)) {
     DEBUG ((DEBUG_ERROR, "EfiLocateProtocolBuffer(gEfiFirmwareManagementProtocolGuid) returned error.  %r \n", Status));
     goto Done;
-  } else if (Status != EFI_NOT_FOUND) {
+  } else if (Status == EFI_NOT_FOUND) {
     Print (L"No Firmware Management Protocols Installed!\n");
     Status = EFI_SUCCESS;
     goto Done;


### PR DESCRIPTION
The intention of the original code was to print a hint message when there is no FMP instance installed. But the current handling has the logic inverted. This change tries to fix it.