### PR TITLE
Fixing the python formats

### DIFF
--- a/.pytool/CISettings.py
+++ b/.pytool/CISettings.py
@@ -14,9 +14,13 @@ from edk2toolext.invocables.edk2_pr_eval import PrEvalSettingsManager
 from edk2toollib.utility_functions import GetHostInfo
 
 
-class Settings(CiSetupSettingsManager, CiBuildSettingsManager, UpdateSettingsManager, SetupSettingsManager,
-               PrEvalSettingsManager):
-
+class Settings(
+    CiSetupSettingsManager,
+    CiBuildSettingsManager,
+    UpdateSettingsManager,
+    SetupSettingsManager,
+    PrEvalSettingsManager,
+):
     def __init__(self):
         self.ActualPackages = []
         self.ActualTargets = []
@@ -31,10 +35,22 @@ class Settings(CiSetupSettingsManager, CiBuildSettingsManager, UpdateSettingsMan
 
     def AddCommandLineOptions(self, parserObj):
         group = parserObj.add_mutually_exclusive_group()
-        group.add_argument("-force_piptools", "--fpt", dest="force_piptools", action="store_true", default=False,
-                           help="Force the system to use pip tools")
-        group.add_argument("-no_piptools", "--npt", dest="no_piptools", action="store_true", default=False,
-                           help="Force the system to not use pip tools")
+        group.add_argument(
+            "-force_piptools",
+            "--fpt",
+            dest="force_piptools",
+            action="store_true",
+            default=False,
+            help="Force the system to use pip tools",
+        )
+        group.add_argument(
+            "-no_piptools",
+            "--npt",
+            dest="no_piptools",
+            action="store_true",
+            default=False,
+            help="Force the system to not use pip tools",
+        )
 
     def RetrieveCommandLineOptions(self, args):
         super().RetrieveCommandLineOptions(args)
@@ -48,22 +64,17 @@ class Settings(CiSetupSettingsManager, CiBuildSettingsManager, UpdateSettingsMan
     # ####################################################################################### #
 
     def GetPackagesSupported(self):
-        ''' return iterable of edk2 packages supported by this build.
-        These should be edk2 workspace relative paths '''
+        """return iterable of edk2 packages supported by this build.
+        These should be edk2 workspace relative paths"""
 
-        return (
-            "SetupDataPkg",
-        )
+        return ("SetupDataPkg",)
 
     def GetArchitecturesSupported(self):
-        ''' return iterable of edk2 architectures supported by this build '''
-        return ("IA32",
-                "X64",
-                "ARM",
-                "AARCH64")
+        """return iterable of edk2 architectures supported by this build"""
+        return ("IA32", "X64", "ARM", "AARCH64")
 
     def GetTargetsSupported(self):
-        ''' return iterable of edk2 target tags supported by this build '''
+        """return iterable of edk2 target tags supported by this build"""
         return ("DEBUG", "RELEASE", "NO-TARGET", "NOOPT")
 
     # ####################################################################################### #
@@ -71,48 +82,45 @@ class Settings(CiSetupSettingsManager, CiBuildSettingsManager, UpdateSettingsMan
     # ####################################################################################### #
 
     def SetPackages(self, list_of_requested_packages):
-        ''' Confirm the requested package list is valid and configure SettingsManager
+        """Confirm the requested package list is valid and configure SettingsManager
         to build the requested packages.
 
         Raise UnsupportedException if a requested_package is not supported
-        '''
-        unsupported = set(list_of_requested_packages) - \
-            set(self.GetPackagesSupported())
-        if(len(unsupported) > 0):
-            logging.critical(
-                "Unsupported Package Requested: " + " ".join(unsupported))
-            raise Exception("Unsupported Package Requested: "
-                            + " ".join(unsupported))
+        """
+        unsupported = set(list_of_requested_packages) - set(self.GetPackagesSupported())
+        if len(unsupported) > 0:
+            logging.critical("Unsupported Package Requested: " + " ".join(unsupported))
+            raise Exception("Unsupported Package Requested: " + " ".join(unsupported))
         self.ActualPackages = list_of_requested_packages
 
     def SetArchitectures(self, list_of_requested_architectures):
-        ''' Confirm the requests architecture list is valid and configure SettingsManager
+        """Confirm the requests architecture list is valid and configure SettingsManager
         to run only the requested architectures.
 
         Raise Exception if a list_of_requested_architectures is not supported
-        '''
-        unsupported = set(list_of_requested_architectures) - \
-            set(self.GetArchitecturesSupported())
-        if(len(unsupported) > 0):
+        """
+        unsupported = set(list_of_requested_architectures) - set(
+            self.GetArchitecturesSupported()
+        )
+        if len(unsupported) > 0:
             logging.critical(
-                "Unsupported Architecture Requested: " + " ".join(unsupported))
+                "Unsupported Architecture Requested: " + " ".join(unsupported)
+            )
             raise Exception(
-                "Unsupported Architecture Requested: " + " ".join(unsupported))
+                "Unsupported Architecture Requested: " + " ".join(unsupported)
+            )
         self.ActualArchitectures = list_of_requested_architectures
 
     def SetTargets(self, list_of_requested_target):
-        ''' Confirm the request target list is valid and configure SettingsManager
+        """Confirm the request target list is valid and configure SettingsManager
         to run only the requested targets.
 
         Raise UnsupportedException if a requested_target is not supported
-        '''
-        unsupported = set(list_of_requested_target) - \
-            set(self.GetTargetsSupported())
-        if(len(unsupported) > 0):
-            logging.critical(
-                "Unsupported Targets Requested: " + " ".join(unsupported))
-            raise Exception("Unsupported Targets Requested: "
-                            + " ".join(unsupported))
+        """
+        unsupported = set(list_of_requested_target) - set(self.GetTargetsSupported())
+        if len(unsupported) > 0:
+            logging.critical("Unsupported Targets Requested: " + " ".join(unsupported))
+            raise Exception("Unsupported Targets Requested: " + " ".join(unsupported))
         self.ActualTargets = list_of_requested_target
 
     # ####################################################################################### #
@@ -120,11 +128,18 @@ class Settings(CiSetupSettingsManager, CiBuildSettingsManager, UpdateSettingsMan
     # ####################################################################################### #
 
     def GetActiveScopes(self):
-        ''' return tuple containing scopes that should be active for this process '''
+        """return tuple containing scopes that should be active for this process"""
         if self.ActualScopes is None:
-            scopes = ("feature-config-apps-ci", "cibuild", "edk2-build", "host-based-test")
+            scopes = (
+                "feature-config-apps-ci",
+                "cibuild",
+                "edk2-build",
+                "host-based-test",
+            )
 
-            self.ActualToolChainTag = shell_environment.GetBuildVars().GetValue("TOOL_CHAIN_TAG", "")
+            self.ActualToolChainTag = shell_environment.GetBuildVars().GetValue(
+                "TOOL_CHAIN_TAG", ""
+            )
 
             is_linux = GetHostInfo().os.upper() == "LINUX"
 
@@ -132,14 +147,15 @@ class Settings(CiSetupSettingsManager, CiBuildSettingsManager, UpdateSettingsMan
                 is_linux = GetHostInfo().os.upper() == "LINUX"
                 # try and import the pip module for basetools
                 try:
-                    import edk2basetools    # noqa: F401
+                    import edk2basetools  # noqa: F401
+
                     self.UseBuiltInBaseTools = True
                 except ImportError:
                     self.UseBuiltInBaseTools = False
                     pass
 
             if self.UseBuiltInBaseTools is True:
-                scopes += ('pipbuild-unix',) if is_linux else ('pipbuild-win',)
+                scopes += ("pipbuild-unix",) if is_linux else ("pipbuild-win",)
                 logging.warning("Using Pip Tools based BaseTools")
             else:
                 logging.warning("Falling back to using in-tree BaseTools")
@@ -155,9 +171,9 @@ class Settings(CiSetupSettingsManager, CiBuildSettingsManager, UpdateSettingsMan
         return self.ActualScopes
 
     def GetRequiredSubmodules(self):
-        ''' return iterable containing RequiredSubmodule objects.
+        """return iterable containing RequiredSubmodule objects.
         If no RequiredSubmodules return an empty iterable
-        '''
+        """
         rs = []
         return rs
 
@@ -165,7 +181,7 @@ class Settings(CiSetupSettingsManager, CiBuildSettingsManager, UpdateSettingsMan
         return "MuConfigApps"
 
     def GetDependencies(self):
-        ''' Return Git Repository Dependencies
+        """Return Git Repository Dependencies
 
         Return an iterable of dictionary objects with the following fields
         {
@@ -176,25 +192,26 @@ class Settings(CiSetupSettingsManager, CiBuildSettingsManager, UpdateSettingsMan
             Full: <optional> Boolean to do shallow or Full checkout.  (default is False)
             ReferencePath: <optional> Workspace relative path to git repo to use as "reference"
         }
-        '''
-        return [
-        ]
+        """
+        return []
 
     def GetPackagesPath(self):
-        ''' Return a list of workspace relative paths that should be mapped as edk2 PackagesPath '''
+        """Return a list of workspace relative paths that should be mapped as edk2 PackagesPath"""
         result = [
             shell_environment.GetBuildVars().GetValue("BASECORE_PATH", ""),
             shell_environment.GetBuildVars().GetValue("MU_PLUS_PATH", ""),
-            shell_environment.GetBuildVars().GetValue("MU_TIANO_PATH", "")
+            shell_environment.GetBuildVars().GetValue("MU_TIANO_PATH", ""),
         ]
         for a in self.GetDependencies():
             result.append(a["Path"])
         return result
 
     def GetWorkspaceRoot(self):
-        ''' get WorkspacePath '''
+        """get WorkspacePath"""
         return os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
-    def FilterPackagesToTest(self, changedFilesList: list, potentialPackagesList: list) -> list:
-        ''' Filter potential packages to test based on changed files. '''
+    def FilterPackagesToTest(
+        self, changedFilesList: list, potentialPackagesList: list
+    ) -> list:
+        """Filter potential packages to test based on changed files."""
         return []

--- a/BasicDevTests.py
+++ b/BasicDevTests.py
@@ -22,7 +22,9 @@ def TestEncodingOk(apath, encodingValue):
         with open(apath, "rb") as f_obj:
             f_obj.read().decode(encodingValue)
     except Exception as exp:
-        logging.critical("Encoding failure: file: {0} type: {1}".format(apath, encodingValue))
+        logging.critical(
+            "Encoding failure: file: {0} type: {1}".format(apath, encodingValue)
+        )
         logging.error("EXCEPTION: while processing {1} - {0}".format(exp, apath))
         return False
     return True
@@ -37,12 +39,13 @@ def TestFilenameLowercase(apath):
 
 
 def PackageAndModuleValidCharacters(apath):
-    ''' check pep8 recommendations for package and module names'''
+    """check pep8 recommendations for package and module names"""
 
-    match = re.match('^[a-z0-9_/.]+$', apath.replace("\\", "/"))
+    match = re.match("^[a-z0-9_/.]+$", apath.replace("\\", "/"))
     if match is None:
         logging.critical(
-            f"PackageAndModuleValidCharacters failure: package or module name {apath} has something invalid")
+            f"PackageAndModuleValidCharacters failure: package or module name {apath} has something invalid"
+        )
         return False
     return True
 
@@ -55,7 +58,9 @@ def TestNoSpaces(apath):
 
 
 def TestRequiredLicense(apath):
-    licenses = ["SPDX-License-Identifier: BSD-2-Clause-Patent", ]
+    licenses = [
+        "SPDX-License-Identifier: BSD-2-Clause-Patent",
+    ]
     try:
         with open(apath, "rb") as f_obj:
             contents = f_obj.read().decode()
@@ -65,7 +70,9 @@ def TestRequiredLicense(apath):
                     found = True
                     break
             if not found:
-                logging.critical(f"License failure: file {apath} has incorrect, invalid, or unsupported license")
+                logging.critical(
+                    f"License failure: file {apath} has incorrect, invalid, or unsupported license"
+                )
                 return False
     except Exception as exp:
         logging.critical(f"License failure: Exception trying to read file: {apath}")
@@ -79,15 +86,17 @@ py_files = glob.glob(os.path.join(p, "**", "*.py"), recursive=True)
 error = 0
 for a in py_files:
     aRelativePath = os.path.relpath(a, os.getcwd())
-    if(not TestEncodingOk(a, "ascii")):
+    if not TestEncodingOk(a, "ascii"):
         error += 1
-    if(not TestFilenameLowercase(aRelativePath)):
+    if not TestFilenameLowercase(aRelativePath):
         error += 1
-    if(not TestNoSpaces(aRelativePath)):
+    if not TestNoSpaces(aRelativePath):
         error += 1
-    if(not TestRequiredLicense(a)):
+    if not TestRequiredLicense(a):
         error += 1
-    if(not PackageAndModuleValidCharacters(aRelativePath)):  # use relative path so only test within package
+    if not PackageAndModuleValidCharacters(
+        aRelativePath
+    ):  # use relative path so only test within package
         error += 1
 
 logging.critical(f"Found {error} error(s) in {len(py_files)} file(s)")

--- a/SetupDataPkg/Tools/GenNCCfgData.py
+++ b/SetupDataPkg/Tools/GenNCCfgData.py
@@ -12,26 +12,39 @@ from collections import OrderedDict
 import base64
 import xmlschema
 
-from SettingSupport.DFCI_SupportLib import DFCI_SupportLib      # noqa: E402
+from SettingSupport.DFCI_SupportLib import DFCI_SupportLib  # noqa: E402
 from CommonUtility import bytes_to_value
-from VariableList import Schema, IntValueFormat, FloatValueFormat, BoolFormat, EnumFormat, StructFormat, ArrayFormat,\
-    vlist_to_binary, read_vlist_from_buffer, uefi_variables_to_knobs, write_csv, read_csv
+from VariableList import (
+    Schema,
+    IntValueFormat,
+    FloatValueFormat,
+    BoolFormat,
+    EnumFormat,
+    StructFormat,
+    ArrayFormat,
+    vlist_to_binary,
+    read_vlist_from_buffer,
+    uefi_variables_to_knobs,
+    write_csv,
+    read_csv,
+)
 
 from GenCfgData import DFCI_SETTINGS_REQUEST_GUID
 
 
 class CGenNCCfgData:
-
     def __init__(self):
         self.initialize()
 
     def initialize(self):
-        self._cfg_page = {'root': {'title': '', 'child': []}}
-        self._cur_page = 'Non-core'
-        self._cfg_page['root']['child'].append({self._cur_page: {'title': self._cur_page, 'child': []}})
+        self._cfg_page = {"root": {"title": "", "child": []}}
+        self._cur_page = "Non-core"
+        self._cfg_page["root"]["child"].append(
+            {self._cur_page: {"title": self._cur_page, "child": []}}
+        )
 
     def get_last_error(self):
-        return ''
+        return ""
 
     def get_cfg_list(self, page_id=None):
         if page_id is None:
@@ -39,30 +52,34 @@ class CGenNCCfgData:
             return self.knob_shim
         else:
             # build a new list for items under a page ID
-            cfgs = [i for i in self.knob_shim if('.'.join(i['path'].split('.')[:2]) == page_id)]
+            cfgs = [
+                i
+                for i in self.knob_shim
+                if (".".join(i["path"].split(".")[:2]) == page_id)
+            ]
             return cfgs
 
     def get_cfg_page(self):
         return self._cfg_page
 
     def get_cfg_item_length(self, item):
-        return item['inst'].format.size_in_bytes()
+        return item["inst"].format.size_in_bytes()
 
     def get_cfg_item_value(self, item, array=False):
-        length = item['inst'].format.size_in_bytes()
+        length = item["inst"].format.size_in_bytes()
         return self.get_value(item, length, array)
 
     def reformat_value_str(self, value_str, bit_length, old_value=None, item=None):
         if item is None:
             raise Exception("Cannot accept item being None for xml parser!!!")
-        obj = item['inst'].format.string_to_object(value_str)
-        new_value = item['inst'].format.object_to_string(obj)
+        obj = item["inst"].format.string_to_object(value_str)
+        new_value = item["inst"].format.object_to_string(obj)
         return new_value
 
     def get_value(self, item, bit_length, array=True, value_str=None):
         if value_str is None:
-            value_str = item['value'].strip()
-        data_inst = item['inst']
+            value_str = item["value"].strip()
+        data_inst = item["inst"]
         if len(value_str) == 0:
             return 0
         obj = data_inst.format.string_to_object(value_str)
@@ -75,30 +92,30 @@ class CGenNCCfgData:
     def set_item_value(self, value_str, item):
         if item is None:
             raise Exception("Cannot accept item being None for xml parser!!!")
-        subknob = item['inst']
+        subknob = item["inst"]
         subknob.value = subknob.format.string_to_object(value_str)
         new_value = subknob.format.object_to_string(subknob.value)
         return new_value
 
     def get_cfg_item_options(self, item):
         tmp_list = []
-        if item['type'].upper() == "ENUM_KNOB":
-            if type(item['inst'].format) is not EnumFormat:
+        if item["type"].upper() == "ENUM_KNOB":
+            if type(item["inst"].format) is not EnumFormat:
                 raise Exception("The item is malformed!!!")
-            tmp_list = [i.name for i in item['inst'].format.values]
-        elif item['type'].upper() == "BOOL_KNOB":
-            if type(item['inst'].format) is not BoolFormat:
+            tmp_list = [i.name for i in item["inst"].format.values]
+        elif item["type"].upper() == "BOOL_KNOB":
+            if type(item["inst"].format) is not BoolFormat:
                 raise Exception("The item is malformed!!!")
-            tmp_list = ['true', 'false']
+            tmp_list = ["true", "false"]
         return tmp_list
 
     def get_page_title(self, page_id, top=None):
         if top is None:
-            top = self.get_cfg_page()['root']
-        for node in top['child']:
+            top = self.get_cfg_page()["root"]
+        for node in top["child"]:
             page_key = next(iter(node))
             if page_id == page_key:
-                return node[page_key]['title']
+                return node[page_key]["title"]
             else:
                 result = self.get_page_title(page_id, node[page_key])
                 if result is not None:
@@ -107,25 +124,26 @@ class CGenNCCfgData:
 
     def get_item_by_path(self, path):
         for each in self.knob_shim:
-            path_list = path.split('.')
+            path_list = path.split(".")
             namespace = path_list[0]
-            var_path = '.'.join(path_list[1:])
-            if each['inst'].knob.namespace == namespace and\
-               each['inst'].name == var_path and\
-               each['inst'].leaf is True:
+            var_path = ".".join(path_list[1:])
+            if (
+                each["inst"].knob.namespace == namespace
+                and each["inst"].name == var_path
+                and each["inst"].leaf is True
+            ):
                 return each
         return None
 
-    def add_cfg_page(self, child, parent='Non-core', title=''):
+    def add_cfg_page(self, child, parent="Non-core", title=""):
         def _add_cfg_page(cfg_page, child, parent):
             key = next(iter(cfg_page))
             if parent == key:
-                cfg_page[key]['child'].append({child: {'title': title,
-                                                       'child': []}})
+                cfg_page[key]["child"].append({child: {"title": title, "child": []}})
                 return True
             else:
                 result = False
-                for each in cfg_page[key]['child']:
+                for each in cfg_page[key]["child"]:
                     if _add_cfg_page(each, child, parent):
                         result = True
                         break
@@ -138,12 +156,16 @@ class CGenNCCfgData:
         # Add the pages for each root knob
         for knob in self.schema.knobs:
             if not self.add_cfg_page(
-                child='.'.join([knob.namespace, knob.name]), parent=knob.namespace, title=knob.name
+                child=".".join([knob.namespace, knob.name]),
+                parent=knob.namespace,
+                title=knob.name,
             ):
                 # The parent page may not exist yet
                 self.add_cfg_page(child=knob.namespace, title=knob.namespace)
                 if not self.add_cfg_page(
-                    child='.'.join([knob.namespace, knob.name]), parent=knob.namespace, title=knob.name
+                    child=".".join([knob.namespace, knob.name]),
+                    parent=knob.namespace,
+                    title=knob.name,
                 ):
                     raise Exception("Failed to add page for knob %s" % knob.name)
 
@@ -154,34 +176,34 @@ class CGenNCCfgData:
             name = data.name
             ord_dict = OrderedDict()
             if itype is IntValueFormat:
-                ord_dict['type'] = 'INTEGER_KNOB'
+                ord_dict["type"] = "INTEGER_KNOB"
             elif itype is FloatValueFormat:
-                ord_dict['type'] = 'FLOAT_KNOB'
+                ord_dict["type"] = "FLOAT_KNOB"
             elif itype is BoolFormat:
-                ord_dict['type'] = 'BOOL_KNOB'
+                ord_dict["type"] = "BOOL_KNOB"
             elif itype is EnumFormat:
-                ord_dict['type'] = 'ENUM_KNOB'
+                ord_dict["type"] = "ENUM_KNOB"
             elif itype is StructFormat:
-                ord_dict['type'] = 'STRUCT_KNOB'
+                ord_dict["type"] = "STRUCT_KNOB"
             elif itype is ArrayFormat:
-                ord_dict['type'] = 'ARRAY_KNOB'
+                ord_dict["type"] = "ARRAY_KNOB"
             else:
                 raise Exception("Unrecognized data format %s!" % str(itype))
-            ord_dict['inst'] = data
-            ord_dict['order'] = idx
-            ord_dict['name'] = name
-            ord_dict['cname'] = name
-            ord_dict['value'] = data.format.object_to_string(data.value)
-            ord_dict['path'] = '.'.join([data.knob.namespace, name])
-            ord_dict['help'] = data.help
+            ord_dict["inst"] = data
+            ord_dict["order"] = idx
+            ord_dict["name"] = name
+            ord_dict["cname"] = name
+            ord_dict["value"] = data.format.object_to_string(data.value)
+            ord_dict["path"] = ".".join([data.knob.namespace, name])
+            ord_dict["help"] = data.help
             ret_list.append(ord_dict)
 
         return ret_list
 
     def sync_shim_and_schema(self):
         for shim in self.knob_shim:
-            data = shim['inst']
-            shim['value'] = data.format.object_to_string(data.value)
+            data = shim["inst"]
+            shim["value"] = data.format.object_to_string(data.value)
 
     def load_from_svd(self, path):
         def handler(id, value):
@@ -225,15 +247,15 @@ class CGenNCCfgData:
         return 0
 
     def generate_csv_file(self, delta_file, bin_file, bin_file2, full=False):
-        fd = open(bin_file, 'rb')
+        fd = open(bin_file, "rb")
         new_data = bytearray(fd.read())
         fd.close()
 
-        if bin_file2 == '':
+        if bin_file2 == "":
             old_data = self.generate_binary_array()
         else:
             old_data = new_data
-            fd = open(bin_file2, 'rb')
+            fd = open(bin_file2, "rb")
             new_data = bytearray(fd.read())
             fd.close()
 
@@ -243,7 +265,7 @@ class CGenNCCfgData:
         self.initialize()
         # TODO: re-enable the xsd validation once updated
         dir_path = os.path.dirname(os.path.abspath(__file__))
-        xsd = xmlschema.XMLSchema(os.path.join(dir_path, 'configschema.xsd'))
+        xsd = xmlschema.XMLSchema(os.path.join(dir_path, "configschema.xsd"))
         # raises exception if validation fails
         xsd.validate(cfg_file)
         self.schema = Schema.load(cfg_file)
@@ -257,12 +279,16 @@ class CGenNCCfgData:
 
 
 def usage():
-    print('\n'.join([
-        "GenNCCfgData Version 0.1",
-        "Usage:",
-        "    GenNCCfgData  GENBIN  XmlFile[;CsvFile]   BinOutFile",
-        "    GenNCCfgData  GENCSV  XmlFile[;BinFile]   CsvOutFile"
-    ]))
+    print(
+        "\n".join(
+            [
+                "GenNCCfgData Version 0.1",
+                "Usage:",
+                "    GenNCCfgData  GENBIN  XmlFile[;CsvFile]   BinOutFile",
+                "    GenNCCfgData  GENCSV  XmlFile[;BinFile]   CsvOutFile",
+            ]
+        )
+    )
 
 
 def main():
@@ -276,22 +302,22 @@ def main():
     command = sys.argv[1].upper()
     out_file = sys.argv[3]
 
-    file_list = sys.argv[2].split(';')
+    file_list = sys.argv[2].split(";")
     if len(file_list) >= 2:
         xml_file = file_list[0]
         csv_file = file_list[1]
     elif len(file_list) == 1:
         xml_file = file_list[0]
-        csv_file = ''
+        csv_file = ""
     else:
         raise Exception("ERROR: Invalid parameter '%s' !" % sys.argv[2])
 
-    cfg_bin_file = ''
-    cfg_bin_file2 = ''
+    cfg_bin_file = ""
+    cfg_bin_file2 = ""
     if csv_file:
         if command == "GENCSV":
             cfg_bin_file = csv_file
-            csv_file = ''
+            csv_file = ""
             if len(file_list) >= 3:
                 cfg_bin_file2 = file_list[2]
 
@@ -303,11 +329,13 @@ def main():
     if command == "GENBIN":
         if len(file_list) == 3:
             old_data = gen_cfg_data.generate_binary_array()
-            fi = open(file_list[2], 'rb')
+            fi = open(file_list[2], "rb")
             new_data = bytearray(fi.read())
             fi.close()
             if len(new_data) != len(old_data):
-                raise Exception("Binary file '%s' length does not match, ignored !" % file_list[2])
+                raise Exception(
+                    "Binary file '%s' length does not match, ignored !" % file_list[2]
+                )
             else:
                 gen_cfg_data.load_default_from_bin(new_data, True)
                 gen_cfg_data.override_default_value(csv_file)
@@ -323,5 +351,5 @@ def main():
     return 0
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     sys.exit(main())

--- a/SetupDataPkg/Tools/SettingSupport/CertSupportLib.py
+++ b/SetupDataPkg/Tools/SettingSupport/CertSupportLib.py
@@ -22,7 +22,6 @@ CertMgrPath = None
 
 
 class CertSupportLib(object):
-
     def get_thumbprint_from_pfx(self, pfxfilename=None):
         global CertMgrPath
 
@@ -44,8 +43,10 @@ class CertSupportLib(object):
 
             parameters = " /c " + pfxfilename
             ret = RunCmd(CertMgrPath, parameters, outfile=t_file)
-            if(ret != 0):
-                logging.critical("Failed to get cert info from Pfx file using CertMgr.exe")
+            if ret != 0:
+                logging.critical(
+                    "Failed to get cert info from Pfx file using CertMgr.exe"
+                )
                 return ret
             f = open(t_file, "r")
 
@@ -57,16 +58,16 @@ class CertSupportLib(object):
             found = False
             for a in pfx_details:
                 a = a.strip()
-                if(len(a)):
-                    if(found):
-                        thumbprint = ''.join(a.split())
+                if len(a):
+                    if found:
+                        thumbprint = "".join(a.split())
                         break
                     else:
-                        if(a == "SHA1 Thumbprint::"):
+                        if a == "SHA1 Thumbprint::":
                             found = True
 
-            if(len(thumbprint) != 40) or (found is False):
-                return 'No thumbprint'
+            if (len(thumbprint) != 40) or (found is False):
+                return "No thumbprint"
 
         except:
             traceback.print_exc()

--- a/SetupDataPkg/Tools/SettingSupport/DFCI_SupportLib.py
+++ b/SetupDataPkg/Tools/SettingSupport/DFCI_SupportLib.py
@@ -17,9 +17,9 @@ import xml.dom.minidom
 import subprocess
 
 try:
-    from StringIO import StringIO       # noqa: F401
+    from StringIO import StringIO  # noqa: F401
 except ImportError:
-    from io import StringIO, BytesIO    # noqa: F401
+    from io import StringIO, BytesIO  # noqa: F401
 
 from builtins import int
 
@@ -38,7 +38,6 @@ CertMgrPath = None
 
 
 class DFCI_SupportLib(object):
-
     def _ReturnSessionIdValue(self, InputString):
         # Session Id:       0xF08A4
         return int(InputString.partition(":")[2].strip(), base=0)
@@ -49,14 +48,14 @@ class DFCI_SupportLib(object):
 
         r = open(resultfile, "r")
         for line in r.readlines():
-            if("SessionId:" in line):
+            if "SessionId:" in line:
                 result_s_id = self._ReturnSessionIdValue(line)
                 break
         r.close()
 
         a = open(applyfile, "r")
         for line in a.readlines():
-            if("SessionId:" in line):
+            if "SessionId:" in line:
                 apply_s_id = self._ReturnSessionIdValue(line)
                 break
         a.close()
@@ -69,11 +68,11 @@ class DFCI_SupportLib(object):
         t = -1
         a = open(resultfile, "r")
         for line in a.readlines():
-            if("Status:" in line):
+            if "Status:" in line:
                 b = line.partition(":")[2]
                 b = b.partition("(")[2]
                 b = b.strip()
-                b = b.rstrip(')')
+                b = b.rstrip(")")
                 t = int(b, base=0)
                 break
         a.close()
@@ -88,7 +87,7 @@ class DFCI_SupportLib(object):
 
         # find the start of the xml string and then copy all lines to xmlstring variable
         for line in a.readlines():
-            if(found):
+            if found:
                 xmlstring += line
             else:
                 if line.lstrip().startswith("<?xml"):
@@ -105,10 +104,10 @@ class DFCI_SupportLib(object):
         root = ET.fromstring(xmlstring)
         for e in root.findall("./Settings/SettingResult"):
             i = e.find("Id")
-            if(i.text == str(id)):
+            if i.text == str(id):
                 r = e.find("Result")
                 break
-        if(r is None):
+        if r is None:
             print("Failed to find ID (%s) in the Xml results" % str(id))
             print(xmlstring)
             return False
@@ -123,7 +122,7 @@ class DFCI_SupportLib(object):
 
         # find the start of the xml string and then copy all lines to xmlstring variable
         for line in a.readlines():
-            if(found):
+            if found:
                 xmlstring += line
             else:
                 if line.lstrip().startswith("<?xml"):
@@ -140,7 +139,9 @@ class DFCI_SupportLib(object):
         root = ET.fromstring(xmlstring)
 
         # Process Settings produced by SettingsXMLLib.py
-        for e in root.findall("./{urn:UefiSettings-Schema}Settings/{urn:UefiSettings-Schema}Setting"):
+        for e in root.findall(
+            "./{urn:UefiSettings-Schema}Settings/{urn:UefiSettings-Schema}Setting"
+        ):
             i = e.find("{urn:UefiSettings-Schema}Id")
             r = e.find("{urn:UefiSettings-Schema}Value")
             handler(i.text, r.text)
@@ -158,7 +159,7 @@ class DFCI_SupportLib(object):
 
         # find the start of the xml string and then copy all lines to xmlstring variable
         for line in a.readlines():
-            if(found):
+            if found:
                 xmlstring += line
             else:
                 if line.lstrip().startswith("<?xml"):
@@ -175,18 +176,18 @@ class DFCI_SupportLib(object):
         root = ET.fromstring(xmlstring)
         for e in root.findall("./Settings/SettingCurrent"):
             i = e.find("Id")
-            if(i.text == str(id)):
+            if i.text == str(id):
                 r = e.find("Value")
                 break
-        if(r is None):
+        if r is None:
             print("Failed to find ID (%s) in the Xml results" % str(id))
             print(xmlstring)
             return False
 
         print("Result Value for Id (%s): %s" % (str(id), r.text))
 
-        if (r.text is None):
-            if valuestring == '':
+        if r.text is None:
+            if valuestring == "":
                 return True
             else:
                 return False
@@ -199,7 +200,7 @@ class DFCI_SupportLib(object):
 
         # find the start of the xml string and then copy all lines to xmlstring variable
         for line in a.readlines():
-            if(found):
+            if found:
                 xmlstring += line
             else:
                 if line.lstrip().startswith("<?xml"):
@@ -218,12 +219,12 @@ class DFCI_SupportLib(object):
 
         for e in root.findall("./Permissions/PermissionCurrent"):
             i = e.find("Id")
-            if(i.text == str(id)):
+            if i.text == str(id):
                 j = e.find("PMask")
-                if (j is not None):
+                if j is not None:
                     r1 = j.text
                 j = e.find("DMask")
-                if (j is not None):
+                if j is not None:
                     r2 = j.text
                 break
         print("Result Value for Id (%s): PMask=%s, DMask=%s" % (str(id), r1, r2))
@@ -236,7 +237,7 @@ class DFCI_SupportLib(object):
 
         # find the start of the xml string and then copy all lines to xmlstring variable
         for line in a.readlines():
-            if(found):
+            if found:
                 xmlstring += line
             else:
                 if line.lstrip().startswith("<?xml"):
@@ -276,7 +277,7 @@ class DFCI_SupportLib(object):
 
         # find the start of the xml string and then copy all lines to xmlstring variable
         for line in a.readlines():
-            if(found):
+            if found:
                 xmlstring += line
             else:
                 if line.lstrip().startswith("<?xml"):
@@ -296,14 +297,17 @@ class DFCI_SupportLib(object):
             i = e.find("Id")
             r = e.find("Result")
 
-            if(r is None):
+            if r is None:
                 print("Failed to find a result node for id (%s)" % i.text.strip())
                 return False
 
             result = int(r.text.strip(), base=0)
             print("Result Status for Id (%s): %s" % (str(i.text.strip()), r.text))
-            if(result != statuscode):
-                print("Error.  Status Code for id (%s) didn't match expected" % i.text.strip())
+            if result != statuscode:
+                print(
+                    "Error.  Status Code for id (%s) didn't match expected"
+                    % i.text.strip()
+                )
                 rc = False
         # done with loop
         return rc
@@ -319,7 +323,7 @@ class DFCI_SupportLib(object):
 
         # find the start of the xml string and then copy all lines to xmlstring variable
         for line in a.readlines():
-            if(found):
+            if found:
                 xmlstring += line
             else:
                 if line.lstrip().startswith("<?xml"):
@@ -339,14 +343,17 @@ class DFCI_SupportLib(object):
             i = e.find("Id")
             r = e.find("Result")
 
-            if(r is None):
+            if r is None:
                 print("Failed to find a result node for id (%s)" % i.text.strip())
                 return False
 
             result = int(r.text.strip(), base=0)
             print("Result Status for Id (%s): %s" % (str(i.text.strip()), r.text))
-            if(result != statuscode):
-                print("Error.  Status Code for id (%s) didn't match expected" % i.text.strip())
+            if result != statuscode:
+                print(
+                    "Error.  Status Code for id (%s) didn't match expected"
+                    % i.text.strip()
+                )
                 rc = False
         # done with loop
         return rc
@@ -361,7 +368,7 @@ class DFCI_SupportLib(object):
 
         # find the start of the xml string and then copy all lines to xmlstring variable
         for line in a.readlines():
-            if(found):
+            if found:
                 xmlstring += line
             else:
                 if line.lstrip().startswith("<?xml"):
@@ -381,7 +388,7 @@ class DFCI_SupportLib(object):
             i = e.find("Id")
             r = e.find("Result")
 
-            if(r is None):
+            if r is None:
                 print("Failed to find a result node for id (%s)" % i.text.strip())
                 return False
 
@@ -390,7 +397,10 @@ class DFCI_SupportLib(object):
             print("Result Status for Id (%s): %s" % (str(i.text.strip()), r.text))
             if index in settingdict:
                 if result != int(settingdict[index], base=0):
-                    print("Error.  Status Code for id (%s) didn't match expected" % i.text.strip())
+                    print(
+                        "Error.  Status Code for id (%s) didn't match expected"
+                        % i.text.strip()
+                    )
                     rc = False
             else:
                 print("Error.  Index %s not in dictionary" % i.text.strip())
@@ -401,7 +411,7 @@ class DFCI_SupportLib(object):
     def extract_payload_from_current(self, resultfile, payloadfile):
         try:
             tree = ET.parse(resultfile)
-            elem = tree.find('./SyncBody/Results/Item/Data')
+            elem = tree.find("./SyncBody/Results/Item/Data")
         except:
             elem = None
 
@@ -418,7 +428,7 @@ class DFCI_SupportLib(object):
     def extract_results_packet(self, resultfile, resultpktfile):
         try:
             tree = ET.parse(resultfile)
-            elem = tree.find('./SyncBody/Results/Item/Data')
+            elem = tree.find("./SyncBody/Results/Item/Data")
         except:
             elem = None
 
@@ -437,57 +447,60 @@ class DFCI_SupportLib(object):
         return 0
 
     def get_status_and_sessionid_from_identity_results(self, resultfile):
-        f = open(resultfile, 'rb')
+        f = open(resultfile, "rb")
         rslt = CertProvisioningResultVariable(f)
         f.close()
         rslt.Print()
         return rslt.Status, rslt.SessionId
 
     def get_sessionid_from_identity_packet(self, identityfile):
-        f = open(identityfile, 'rb')
+        f = open(identityfile, "rb")
         rslt = CertProvisioningApplyVariable(f)
         f.close()
         rslt.Print()
         return rslt.SessionId
 
     def get_status_and_sessionid_from_permission_results(self, resultfile):
-        f = open(resultfile, 'rb')
+        f = open(resultfile, "rb")
         rslt = PermissionResultVariable(f)
         f.close()
         rslt.Print()
         return rslt.Status, rslt.SessionId
 
     def get_sessionid_from_permission_packet(self, identityfile):
-        f = open(identityfile, 'rb')
+        f = open(identityfile, "rb")
         rslt = PermissionApplyVariable(f)
         f.close()
         rslt.Print()
         return rslt.SessionId
 
     def get_status_and_sessionid_from_settings_results(self, resultfile, checktype):
-        f = open(resultfile, 'rb')
+        f = open(resultfile, "rb")
         rslt = SecureSettingsResultVariable(f)
         rslt.Print()
         f.close()
         if (checktype != "FULL") and (checktype != "BASIC"):
-            print('checktype invalid')
+            print("checktype invalid")
             # EFI_DEVICE_ERROR
             return 0x8000000000000007, 0
         RsltRc = rslt.Status
         if RsltRc == 0 and checktype == "FULL":
             try:
                 tree = ET.fromstring(rslt.Payload)
-                for elem in tree.findall('./Settings/SettingResult'):
-                    rc = int(elem.find('Result').text, 0)
+                for elem in tree.findall("./Settings/SettingResult"):
+                    rc = int(elem.find("Result").text, 0)
                     if rc != 0:
                         RsltRc = rc
-                    print('Setting %s - Code %s' % (elem.find('Id').text, elem.find('Result').text))
+                    print(
+                        "Setting %s - Code %s"
+                        % (elem.find("Id").text, elem.find("Result").text)
+                    )
             except:
                 traceback.print_exc()
         return RsltRc, rslt.SessionId
 
     def get_payload_from_permissions_results(self, resultfile, payloadfile):
-        f = open(resultfile, 'rb')
+        f = open(resultfile, "rb")
         rslt = PermissionResultVariable(f)
         rslt.Print()
         f.close()
@@ -498,7 +511,7 @@ class DFCI_SupportLib(object):
         return 0
 
     def get_payload_from_settings_results(self, resultfile, payloadfile):
-        f = open(resultfile, 'rb')
+        f = open(resultfile, "rb")
         rslt = SecureSettingsResultVariable(f)
         rslt.Print()
         f.close()
@@ -509,7 +522,7 @@ class DFCI_SupportLib(object):
         return 0
 
     def get_sessionid_from_settings_packet(self, settingsfile):
-        f = open(settingsfile, 'rb')
+        f = open(settingsfile, "rb")
         rslt = SecureSettingsApplyVariable(f)
         f.close()
         rslt.Print()
@@ -524,7 +537,7 @@ class DFCI_SupportLib(object):
             result = 0
             for e in root.findall("./SyncBody/Status"):
                 i = e.find("Data")
-                if (i.text != "200"):
+                if i.text != "200":
                     result = 0x8000000000000007  # EFI_DEVICE_ERROR
                     break
                 result = 0
@@ -545,43 +558,43 @@ class DFCI_SupportLib(object):
         else:
             Ret = UefiStatusCode().ConvertHexString64ToString(StatusCode)
 
-        if Ret == '':
-            Ret = '%x' % StatusCode
+        if Ret == "":
+            Ret = "%x" % StatusCode
         return Ret
 
     def print_xml_payload(self, XmlFileName):
         try:
             tree = xml.dom.minidom.parse(XmlFileName)
-            print('%s' % tree.toprettyxml())
+            print("%s" % tree.toprettyxml())
         except:
             traceback.print_exc()
-            print('Unable to print settings XML')
+            print("Unable to print settings XML")
 
-    def build_target_parameters(self, Version, SerialNumber='', Mfg='', ProdName=''):
+    def build_target_parameters(self, Version, SerialNumber="", Mfg="", ProdName=""):
         rslt = []
 
-        if Version == 'V1':
-            rslt.append('--HdrVersion')
-            rslt.append('1')
-            if SerialNumber != '':
-                rslt.append('--SnTarget')
+        if Version == "V1":
+            rslt.append("--HdrVersion")
+            rslt.append("1")
+            if SerialNumber != "":
+                rslt.append("--SnTarget")
                 rslt.append(SerialNumber)
 
-        elif Version == 'V2':
-            rslt.append('--HdrVersion')
-            rslt.append('2')
-            if Mfg != '':
-                rslt.append('--SMBIOSMfg')
+        elif Version == "V2":
+            rslt.append("--HdrVersion")
+            rslt.append("2")
+            if Mfg != "":
+                rslt.append("--SMBIOSMfg")
                 rslt.append(Mfg)
-            if ProdName != '':
-                rslt.append('--SMBIOSProd')
+            if ProdName != "":
+                rslt.append("--SMBIOSProd")
                 rslt.append(ProdName)
-            if SerialNumber != '':
-                rslt.append('--SMBIOSSerial')
+            if SerialNumber != "":
+                rslt.append("--SMBIOSSerial")
                 rslt.append(SerialNumber)
 
         else:
-            raise ValueError('Invalid version {}'.format(Version))
+            raise ValueError("Invalid version {}".format(Version))
 
         return rslt
 
@@ -591,19 +604,19 @@ class DFCI_SupportLib(object):
             tree = ET.parse(XmlFileName)
             root = tree.getroot()
 
-            elem = root.findall('./Identifiers/Identifier')
+            elem = root.findall("./Identifiers/Identifier")
             for e in elem:
-                xid = e.find('Id')
-                pn = e.find('Value')
+                xid = e.find("Id")
+                pn = e.find("Value")
                 # print(' {0} = {1}'.format(xid.text, pn.text)
                 d[xid.text] = pn.text
 
             for key in d:
-                print(' Key {0} has the value of {1}'.format(key, d[key]))
+                print(" Key {0} has the value of {1}".format(key, d[key]))
 
         except:
             traceback.print_exc()
-            print('Unable to extract DeviceIdElements.')
+            print("Unable to extract DeviceIdElements.")
             d = {}
 
         return d
@@ -617,9 +630,9 @@ class DFCI_SupportLib(object):
 
         d = self.get_device_ids(XmlFileName)
 
-        Manufacturer = d['Manufacturer']
-        ProductName = d['Product Name']
-        SerialNumber = d['Serial Number']
+        Manufacturer = d["Manufacturer"]
+        ProductName = d["Product Name"]
+        SerialNumber = d["Serial Number"]
 
         rc = 0
         if Mfg != Manufacturer:
@@ -636,13 +649,13 @@ class DFCI_SupportLib(object):
             tree = ET.parse(XmlFileName)
             root = tree.getroot()
 
-            elem = root.find('./DfciVersion')
+            elem = root.find("./DfciVersion")
             d = elem.text
-            print('Dfci Version detected as %s' % d)
+            print("Dfci Version detected as %s" % d)
 
         except:
             traceback.print_exc()
-            print('Unable to extract DfciVersion from %s' % XmlFileName)
+            print("Unable to extract DfciVersion from %s" % XmlFileName)
             d = None
 
         return d
@@ -663,19 +676,19 @@ class DFCI_SupportLib(object):
             tree = ET.parse(XmlFileName)
             root = tree.getroot()
 
-            elem = root.findall('./Certificates/Certificate')
+            elem = root.findall("./Certificates/Certificate")
             for e in elem:
-                xid = e.find('Id')
-                pn = e.find('Value')
+                xid = e.find("Id")
+                pn = e.find("Value")
                 # print(' {0} = {1}'.format(xid.text, pn.text)
                 d[xid.text] = pn.text
 
             for key in d:
-                print(' Key {0} has the value of {1}'.format(key, d[key]))
+                print(" Key {0} has the value of {1}".format(key, d[key]))
 
         except:
             traceback.print_exc()
-            print('Unable to extract DeviceIdElements.')
+            print("Unable to extract DeviceIdElements.")
             d = {}
 
         return d
@@ -688,9 +701,11 @@ class DFCI_SupportLib(object):
     # Determine if the DUT is online by pinging it
     #
     def is_device_online(self, ipaddress):
-        output = subprocess.Popen(["ping.exe", "-n", "1", ipaddress], stdout=subprocess.PIPE).communicate()[0]
+        output = subprocess.Popen(
+            ["ping.exe", "-n", "1", ipaddress], stdout=subprocess.PIPE
+        ).communicate()[0]
 
-        if (b'TTL' in output):
+        if b"TTL" in output:
             return True
         else:
             return False
@@ -702,8 +717,10 @@ class DFCI_SupportLib(object):
 
             # check if exists
             if SignToolPath is None or not os.path.exists(SignToolPath):
-                raise Exception("Can't find signtool.exe on this machine.  Please install the Windows 10 WDK - "
-                                "https://developer.microsoft.com/en-us/windows/hardware/windows-driver-kit")
+                raise Exception(
+                    "Can't find signtool.exe on this machine.  Please install the Windows 10 WDK - "
+                    "https://developer.microsoft.com/en-us/windows/hardware/windows-driver-kit"
+                )
 
         return SignToolPath
 
@@ -714,7 +731,9 @@ class DFCI_SupportLib(object):
 
             # check if exists
             if CertMgrPath is None or not os.path.exists(CertMgrPath):
-                raise Exception("Can't find certmgr.exe on this machine.  Please install the Windows 10 WDK - "
-                                "https://developer.microsoft.com/en-us/windows/hardware/windows-driver-kit")
+                raise Exception(
+                    "Can't find certmgr.exe on this machine.  Please install the Windows 10 WDK - "
+                    "https://developer.microsoft.com/en-us/windows/hardware/windows-driver-kit"
+                )
 
         return CertMgrPath

--- a/SetupDataPkg/Tools/SettingSupport/Data/SecureSettingVariable.py
+++ b/SetupDataPkg/Tools/SettingSupport/Data/SecureSettingVariable.py
@@ -29,7 +29,7 @@ class SecureSettingsApplyVariable(object):
     VERSION_V2 = 2
 
     def __init__(self, filestream=None, HdrVersion=1):
-        if (HdrVersion != self.VERSION_V1 and HdrVersion != self.VERSION_V2):
+        if HdrVersion != self.VERSION_V1 and HdrVersion != self.VERSION_V2:
             raise Exception("Invalid version specified")
 
         print("Processing Version %s" % HdrVersion)
@@ -58,7 +58,7 @@ class SecureSettingsApplyVariable(object):
         self.SerialOffset = 0
         self.PayloadOffset = 0
 
-        if(filestream is None):
+        if filestream is None:
             self.HeaderSignature = self.HEADER_SIG_VALUE
             self.HeaderVersion = HdrVersion
         else:
@@ -68,7 +68,7 @@ class SecureSettingsApplyVariable(object):
     # Method to un-serialize from a filestream
     #
     def PopulateFromFileStream(self, fs):
-        if(fs is None):
+        if fs is None:
             raise Exception("Invalid File stream")
 
         # only populate from file stream those parts that are complete in the file stream
@@ -78,7 +78,7 @@ class SecureSettingsApplyVariable(object):
         fs.seek(offset)
 
         # minimum size of the static header data
-        if((end - offset) < self.STATIC_STRUCT_SIZE_V1):
+        if (end - offset) < self.STATIC_STRUCT_SIZE_V1:
             raise Exception("Invalid file stream size")
 
         self.HeaderSignature = fs.read(4).decode()
@@ -89,14 +89,14 @@ class SecureSettingsApplyVariable(object):
         self.rsvd2 = struct.unpack("=B", fs.read(1))[0]
         self.rsvd3 = struct.unpack("=B", fs.read(1))[0]
 
-        if (self.HeaderVersion == self.VERSION_V1):
+        if self.HeaderVersion == self.VERSION_V1:
             self.SNTarget = struct.unpack("=Q", fs.read(8))[0]
             self.SessionId = struct.unpack("=I", fs.read(4))[0]
             self.PayloadSize = struct.unpack("=H", fs.read(2))[0]
 
-        elif (self.HeaderVersion == self.VERSION_V2):
+        elif self.HeaderVersion == self.VERSION_V2:
             # minimum size for v2 data
-            if((end - offset) < self.STATIC_STRUCT_SIZE_V2):
+            if (end - offset) < self.STATIC_STRUCT_SIZE_V2:
                 raise Exception("Invalid V2 file stream size")
             self.SessionId = struct.unpack("=I", fs.read(4))[0]
             self.MfgOffset = struct.unpack("=H", fs.read(2))[0]
@@ -105,18 +105,22 @@ class SecureSettingsApplyVariable(object):
             self.PayloadSize = struct.unpack("=H", fs.read(2))[0]
             self.PayloadOffset = struct.unpack("=H", fs.read(2))[0]
 
-            if (end - fs.tell() < self.PayloadOffset):
+            if end - fs.tell() < self.PayloadOffset:
                 raise Exception("Packet too small for SmBiosString")
 
-            if ((self.MfgOffset >= self.ProductOffset)
-               or (self.ProductOffset >= self.SerialOffset)
-               or (self.SerialOffset >= self.PayloadOffset)):
+            if (
+                (self.MfgOffset >= self.ProductOffset)
+                or (self.ProductOffset >= self.SerialOffset)
+                or (self.SerialOffset >= self.PayloadOffset)
+            ):
                 raise Exception("Invalid Offset Structure")
 
             Temp = fs.tell()
             if Temp != self.MfgOffset:
                 raise Exception("Invalid Mfg Offset")
-            self.Manufacturer = fs.read(self.ProductOffset - self.MfgOffset - 1).decode()
+            self.Manufacturer = fs.read(
+                self.ProductOffset - self.MfgOffset - 1
+            ).decode()
             Temp = struct.unpack("=B", fs.read(1))[0]
             if Temp != 0:
                 raise Exception("Invalid NULL in Mfg")
@@ -124,7 +128,9 @@ class SecureSettingsApplyVariable(object):
             Temp = fs.tell()
             if Temp != self.ProductOffset:
                 raise Exception("Invalid Product Offset")
-            self.ProductName = fs.read(self.SerialOffset - self.ProductOffset - 1).decode()
+            self.ProductName = fs.read(
+                self.SerialOffset - self.ProductOffset - 1
+            ).decode()
             Temp = struct.unpack("=B", fs.read(1))[0]
             if Temp != 0:
                 raise Exception("Invalid NULL in ProductName")
@@ -132,7 +138,9 @@ class SecureSettingsApplyVariable(object):
             Temp = fs.tell()
             if Temp != self.SerialOffset:
                 raise Exception("Invalid SerialOffset Offset")
-            self.SerialNumber = fs.read(self.PayloadOffset - self.SerialOffset - 1).decode()
+            self.SerialNumber = fs.read(
+                self.PayloadOffset - self.SerialOffset - 1
+            ).decode()
             Temp = struct.unpack("=B", fs.read(1))[0]
             if Temp != 0:
                 raise Exception("Invalid NULL in SerialNumber")
@@ -143,23 +151,25 @@ class SecureSettingsApplyVariable(object):
         self._PayloadXml = None
         self.Signature = None
 
-        if((end - fs.tell()) < self.PayloadSize):
+        if (end - fs.tell()) < self.PayloadSize:
             raise Exception("Invalid file stream size (payload size incorrect)")
 
-        self.Payload = fs.read(self.PayloadSize).decode('utf-8')
+        self.Payload = fs.read(self.PayloadSize).decode("utf-8")
         prep = self.Payload
-        prep = prep.rstrip('\x00')
+        prep = prep.rstrip("\x00")
         self._PayloadXml = xml.dom.minidom.parseString(prep)
 
-        if((end - fs.tell()) > 0):
+        if (end - fs.tell()) > 0:
             self.Signature = WinCert.Factory(fs)
 
     def AddXmlPayload(self, xmlstring):
-        if(self.Payload):
-            raise Exception("Can't Add an XML payload to an object already containing payload")
+        if self.Payload:
+            raise Exception(
+                "Can't Add an XML payload to an object already containing payload"
+            )
         # get rid of extra whitespace and new line chars. This changes newline to blank which i don't like but better
         # than before.  If replace with '' then xml attributes are messed up
-        xml_clean = ' '.join(xmlstring.split())
+        xml_clean = " ".join(xmlstring.split())
         self.Payload = xml_clean
         self._PayloadXml = xml.dom.minidom.parseString(xml_clean)
         self.PayloadSize = len(xml_clean)
@@ -173,41 +183,41 @@ class SecureSettingsApplyVariable(object):
         print("  HeaderVersion:    0x%X" % self.HeaderVersion)
         print("  SessionId:        0x%X" % self.SessionId)
         print("  Payload Size:     0x%X" % self.PayloadSize)
-        if (self.HeaderVersion == self.VERSION_V1):
+        if self.HeaderVersion == self.VERSION_V1:
             print("  SN Target:        %d" % self.SNTarget)
-        elif (self.HeaderVersion == self.VERSION_V2):
+        elif self.HeaderVersion == self.VERSION_V2:
             print("  Manufacturer:     %s" % self.Manufacturer)
             print("  Product Name:     %s" % self.ProductName)
             print("  SerialNumber:     %s" % self.SerialNumber)
         else:
             raise Exception("Invalid header version")
 
-        if(self._PayloadXml is not None):
+        if self._PayloadXml is not None:
             print("%s" % self._PayloadXml.toprettyxml())
         else:
             print("XML TREE DOESN'T EXIST")
 
-        if(ShowRawXmlAsBytes and (self.Payload is not None)):
+        if ShowRawXmlAsBytes and (self.Payload is not None):
             print("  Payload Bytes:    ")
             ndbl = list(bytearray(self.Payload.encode()))
             print(type(ndbl))
             PrintByteList(ndbl)
 
-        if(self.Signature is not None):
+        if self.Signature is not None:
             self.Signature.Print()
 
     def Write(self, fs):
-        fs.write(self.HeaderSignature.encode('utf-8'))
+        fs.write(self.HeaderSignature.encode("utf-8"))
         fs.write(struct.pack("=B", self.HeaderVersion))
         fs.write(struct.pack("=B", self.Rsvd1))
         fs.write(struct.pack("=B", self.Rsvd2))
         fs.write(struct.pack("=B", self.Rsvd3))
 
-        if (self.HeaderVersion == self.VERSION_V1):
+        if self.HeaderVersion == self.VERSION_V1:
             fs.write(struct.pack("=Q", self.SNTarget))
             fs.write(struct.pack("=I", self.SessionId))
             fs.write(struct.pack("=H", self.PayloadSize))
-        elif (self.HeaderVersion == self.VERSION_V2):
+        elif self.HeaderVersion == self.VERSION_V2:
             fs.write(struct.pack("=I", self.SessionId))
             fs.write(struct.pack("=H", self.MfgOffset))
             self.ProductOffset = self.MfgOffset + len(self.Manufacturer) + 1
@@ -217,17 +227,17 @@ class SecureSettingsApplyVariable(object):
             fs.write(struct.pack("=H", self.SerialOffset))
             fs.write(struct.pack("=H", self.PayloadSize))
             fs.write(struct.pack("=H", self.PayloadOffset))
-            fs.write(self.Manufacturer.encode('utf-8'))
+            fs.write(self.Manufacturer.encode("utf-8"))
             fs.write(struct.pack("=B", 0))  # NULL Terminator
-            fs.write(self.ProductName.encode('utf-8'))
+            fs.write(self.ProductName.encode("utf-8"))
             fs.write(struct.pack("=B", 0))  # NULL Terminator
-            fs.write(self.SerialNumber.encode('utf-8'))
+            fs.write(self.SerialNumber.encode("utf-8"))
             fs.write(struct.pack("=B", 0))  # NULL Terminator
         else:
             raise Exception("Invalid header version")
 
-        fs.write(self.Payload.encode('utf-8'))
-        if(self.Signature is not None):
+        fs.write(self.Payload.encode("utf-8"))
+        if self.Signature is not None:
             self.Signature.Write(fs)
 
 
@@ -241,7 +251,7 @@ class SecureSettingsResultVariable(object):
     VERSION = 1
 
     def __init__(self, filestream=None):
-        if(filestream is None):
+        if filestream is None:
             self.HeaderSignature = SecureSettingsResultVariable.HEADER_SIG_VALUE
             self.HeaderVersion = SecureSettingsResultVariable.VERSION
             self.Status = 0
@@ -258,7 +268,7 @@ class SecureSettingsResultVariable(object):
     # Method to un-serialize from a filestream
     #
     def PopulateFromFileStream(self, fs):
-        if(fs is None):
+        if fs is None:
             raise Exception("Invalid File stream")
 
         # only populate from file stream those parts that are complete in the file stream
@@ -268,7 +278,7 @@ class SecureSettingsResultVariable(object):
         fs.seek(offset)
 
         # size of the static header data
-        if((end - offset) < SecureSettingsResultVariable.STATIC_STRUCT_SIZE):
+        if (end - offset) < SecureSettingsResultVariable.STATIC_STRUCT_SIZE:
             raise Exception("Invalid file stream size")
 
         self.HeaderSignature = str(fs.read(4))
@@ -281,15 +291,17 @@ class SecureSettingsResultVariable(object):
         self.Payload = None
         self._XmlTree = None
 
-        if((end - fs.tell()) < self.PayloadSize):
-            raise Exception("Invalid file stream size (Payload).  %d" % self.PayloadSize)
+        if (end - fs.tell()) < self.PayloadSize:
+            raise Exception(
+                "Invalid file stream size (Payload).  %d" % self.PayloadSize
+            )
 
         # is it possible to have 0 sized
-        if(self.PayloadSize > 0):
+        if self.PayloadSize > 0:
             self.Payload = fs.read(self.PayloadSize)
             self.Payload = self.Payload.decode("utf-8")
             # remove ending NULL if there.  this only happens in some cases
-            self.Payload = self.Payload.rstrip('\x00')
+            self.Payload = self.Payload.rstrip("\x00")
             self._XmlTree = xml.dom.minidom.parseString(self.Payload)
 
     #
@@ -300,14 +312,17 @@ class SecureSettingsResultVariable(object):
         print("  HeaderSignature:  %s" % self.HeaderSignature)
         print("  HeaderVersion:    0x%X" % self.HeaderVersion)
         print("  SessionId:        0x%X" % (self.SessionId))
-        print("  Status:           %s (0x%X)" % (UefiStatusCode().Convert64BitToString(self.Status), self.Status))
+        print(
+            "  Status:           %s (0x%X)"
+            % (UefiStatusCode().Convert64BitToString(self.Status), self.Status)
+        )
         print("  Payload Size:     0x%X" % self.PayloadSize)
-        if(self._XmlTree is not None):
+        if self._XmlTree is not None:
             print("%s" % self._XmlTree.toprettyxml())
         else:
             print("XML TREE DOESN'T EXIST")
 
-        if(ShowRawXmlAsBytes and (self.Payload is not None)):
+        if ShowRawXmlAsBytes and (self.Payload is not None):
             print("  Payload Bytes:    ")
             ndbl = list(bytearray(self.Payload.encode()))
             print(type(ndbl))
@@ -316,14 +331,14 @@ class SecureSettingsResultVariable(object):
     def Write(self, fs):
         raise Exception("Unsupported/Unnecessary function")
 
-        '''fs.write(self.HeaderSignature.encode('utf-8'))
+        """fs.write(self.HeaderSignature.encode('utf-8'))
         fs.write(struct.pack("=B", self.HeaderVersion))
         fs.write(struct.pack("=B", self.Identity))
         fs.write(struct.pack("=H", self.NewDataSize))
         fs.write(self.NewDataBuffer)
         if(self.Signature != None):
             self.Signature.Write(fs)
-            '''
+            """
 
 
 ##
@@ -337,14 +352,14 @@ class SecureSettingsCurrentVariable(object):
         self._Payload = None
         # private xml structure
         self._XmlTree = None
-        if(filestream is not None):
+        if filestream is not None:
             self.PopulateFromFileStream(filestream)
 
     #
     # Method to un-serialize from a filestream
     #
     def PopulateFromFileStream(self, fs):
-        if(fs is None):
+        if fs is None:
             raise Exception("Invalid File stream")
 
         # only populate from file stream those parts that are complete in the file stream
@@ -354,10 +369,10 @@ class SecureSettingsCurrentVariable(object):
         fs.seek(offset)
 
         # no data
-        if((end - offset) < 1):
+        if (end - offset) < 1:
             raise Exception("Invalid file stream size.  No data")
         self._Payload = fs.read()
-        self._Payload = self._Payload.rstrip('\x00')
+        self._Payload = self._Payload.rstrip("\x00")
         self._XmlTree = xml.dom.minidom.parseString(self._Payload)
 
     #
@@ -365,12 +380,12 @@ class SecureSettingsCurrentVariable(object):
     #
     def Print(self):
         print("Current Settings XML")
-        if(self._XmlTree is not None):
+        if self._XmlTree is not None:
             print("%s" % self._XmlTree.toprettyxml())
         else:
             print("XML TREE DOESN'T EXIST")
 
     def Write(self, fs):
-        if(self._Payload is None):
+        if self._Payload is None:
             raise Exception("No payload to write")
         fs.write(self._Payload)

--- a/SetupDataPkg/Tools/SettingSupport/UefiVariablesSupportLib.py
+++ b/SetupDataPkg/Tools/SettingSupport/UefiVariablesSupportLib.py
@@ -5,7 +5,15 @@
 # Copyright (c), Microsoft Corporation
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 
-from ctypes import windll, c_wchar_p, c_void_p, c_int, c_char, create_string_buffer, WinError
+from ctypes import (
+    windll,
+    c_wchar_p,
+    c_void_p,
+    c_int,
+    c_char,
+    create_string_buffer,
+    WinError,
+)
 import logging
 import win32api
 import win32process
@@ -16,28 +24,57 @@ EFI_VAR_MAX_BUFFER_SIZE = 1024 * 1024
 
 
 class UefiVariable(object):
-
     def __init__(self):
         # enable required SeSystemEnvironmentPrivilege privilege
-        privilege = win32security.LookupPrivilegeValue(None, 'SeSystemEnvironmentPrivilege')
-        token = win32security.OpenProcessToken(win32process.GetCurrentProcess(),
-                                               win32security.TOKEN_READ | win32security.TOKEN_ADJUST_PRIVILEGES)
-        win32security.AdjustTokenPrivileges(token, False, [(privilege, win32security.SE_PRIVILEGE_ENABLED)])
+        privilege = win32security.LookupPrivilegeValue(
+            None, "SeSystemEnvironmentPrivilege"
+        )
+        token = win32security.OpenProcessToken(
+            win32process.GetCurrentProcess(),
+            win32security.TOKEN_READ | win32security.TOKEN_ADJUST_PRIVILEGES,
+        )
+        win32security.AdjustTokenPrivileges(
+            token, False, [(privilege, win32security.SE_PRIVILEGE_ENABLED)]
+        )
         win32api.CloseHandle(token)
 
         # import firmware variable API
         try:
-            self._GetFirmwareEnvironmentVariable = kernel32.GetFirmwareEnvironmentVariableW
+            self._GetFirmwareEnvironmentVariable = (
+                kernel32.GetFirmwareEnvironmentVariableW
+            )
             self._GetFirmwareEnvironmentVariable.restype = c_int
-            self._GetFirmwareEnvironmentVariable.argtypes = [c_wchar_p, c_wchar_p, c_void_p, c_int]
-            self._SetFirmwareEnvironmentVariable = kernel32.SetFirmwareEnvironmentVariableW
+            self._GetFirmwareEnvironmentVariable.argtypes = [
+                c_wchar_p,
+                c_wchar_p,
+                c_void_p,
+                c_int,
+            ]
+            self._SetFirmwareEnvironmentVariable = (
+                kernel32.SetFirmwareEnvironmentVariableW
+            )
             self._SetFirmwareEnvironmentVariable.restype = c_int
-            self._SetFirmwareEnvironmentVariable.argtypes = [c_wchar_p, c_wchar_p, c_void_p, c_int]
-            self._SetFirmwareEnvironmentVariableEx = kernel32.SetFirmwareEnvironmentVariableExW
+            self._SetFirmwareEnvironmentVariable.argtypes = [
+                c_wchar_p,
+                c_wchar_p,
+                c_void_p,
+                c_int,
+            ]
+            self._SetFirmwareEnvironmentVariableEx = (
+                kernel32.SetFirmwareEnvironmentVariableExW
+            )
             self._SetFirmwareEnvironmentVariableEx.restype = c_int
-            self._SetFirmwareEnvironmentVariableEx.argtypes = [c_wchar_p, c_wchar_p, c_void_p, c_int, c_int]
+            self._SetFirmwareEnvironmentVariableEx.argtypes = [
+                c_wchar_p,
+                c_wchar_p,
+                c_void_p,
+                c_int,
+                c_int,
+            ]
         except:
-            logging.warn("G[S]etFirmwareEnvironmentVariableW function doesn't seem to exist")
+            logging.warn(
+                "G[S]etFirmwareEnvironmentVariableW function doesn't seem to exist"
+            )
             pass
 
     #
@@ -70,11 +107,18 @@ class UefiVariable(object):
         err = 0
         efi_var = create_string_buffer(EFI_VAR_MAX_BUFFER_SIZE)
         if self._GetFirmwareEnvironmentVariable is not None:
-            logging.info("calling GetFirmwareEnvironmentVariable( name='%s', GUID='%s' ).." % (name, "{%s}" % guid))
-            length = self._GetFirmwareEnvironmentVariable(name, "{%s}" % guid, efi_var, EFI_VAR_MAX_BUFFER_SIZE)
+            logging.info(
+                "calling GetFirmwareEnvironmentVariable( name='%s', GUID='%s' ).."
+                % (name, "{%s}" % guid)
+            )
+            length = self._GetFirmwareEnvironmentVariable(
+                name, "{%s}" % guid, efi_var, EFI_VAR_MAX_BUFFER_SIZE
+            )
         if (0 == length) or (efi_var is None):
             err = kernel32.GetLastError()
-            logging.error('GetFirmwareEnvironmentVariable[Ex] failed (GetLastError = 0x%x)' % err)
+            logging.error(
+                "GetFirmwareEnvironmentVariable[Ex] failed (GetLastError = 0x%x)" % err
+            )
             logging.error(WinError())
             return (err, None, WinError(err))
         return (err, efi_var[:length], None)
@@ -92,22 +136,34 @@ class UefiVariable(object):
         else:
             var_len = len(var)
         success = 0  # Fail
-        if(attrs is None):
+        if attrs is None:
             if self._SetFirmwareEnvironmentVariable is not None:
-                logging.info("Calling SetFirmwareEnvironmentVariable (name='%s', Guid='%s')..." %
-                             (name, "{%s}" % guid, ))
-                success = self._SetFirmwareEnvironmentVariable(name, "{%s}" % guid, var, var_len)
+                logging.info(
+                    "Calling SetFirmwareEnvironmentVariable (name='%s', Guid='%s')..."
+                    % (
+                        name,
+                        "{%s}" % guid,
+                    )
+                )
+                success = self._SetFirmwareEnvironmentVariable(
+                    name, "{%s}" % guid, var, var_len
+                )
         else:
             attrs = int(attrs)
             if self._SetFirmwareEnvironmentVariableEx is not None:
                 logging.info(
-                    "Calling SetFirmwareEnvironmentVariableEx( name='%s', GUID='%s', length=0x%X, attributes=0x%X ).." %
-                    (name, "{%s}" % guid, var_len, attrs))
-                success = self._SetFirmwareEnvironmentVariableEx(name, "{%s}" % guid, var, var_len, attrs)
+                    "Calling SetFirmwareEnvironmentVariableEx( name='%s', GUID='%s', length=0x%X, attributes=0x%X ).."
+                    % (name, "{%s}" % guid, var_len, attrs)
+                )
+                success = self._SetFirmwareEnvironmentVariableEx(
+                    name, "{%s}" % guid, var, var_len, attrs
+                )
 
         if 0 == success:
             err = kernel32.GetLastError()
-            logging.error('SetFirmwareEnvironmentVariable failed (GetLastError = 0x%x)' % err)
+            logging.error(
+                "SetFirmwareEnvironmentVariable failed (GetLastError = 0x%x)" % err
+            )
             logging.error(WinError())
             error_string = WinError(err)
         return (success, err, error_string)

--- a/py-requirements.txt
+++ b/py-requirements.txt
@@ -1,7 +1,7 @@
 pytest
 pytest-html
 pytest-cov
-flake8
+flake8~=5.0.0 # MU_CHANGE - update to 5.0.0 or later
 pyopenssl
 pefile
 xmlschema


### PR DESCRIPTION
Flake8 just updated to 5.0.0 recently and start to catch new error that was not found. This is a designated PR to fix format errors on existing python files. No functional changes.

This change also starts to require flake8 to be at least v5.0.0 or later to perform pipeline checks.