### PR TITLE
Parse RuntimeData in ConfApp

### DIFF
--- a/SetupDataPkg/ConfApp/SetupConf.c
+++ b/SetupDataPkg/ConfApp/SetupConf.c
@@ -335,6 +335,7 @@ ApplySettings (
 
     // only care about our target
     if ((0 != AsciiStrnCmp (Id, DFCI_OEM_SETTING_ID__CONF, DFCI_MAX_ID_LEN)) &&
+        (0 != AsciiStrnCmp (Id, DFCI_OEM_SETTING_ID__RUNTIMECONF, DFCI_MAX_ID_LEN)) &&
         (0 != AsciiStrnCmp (Id, SINGLE_SETTING_PROVIDER_START, sizeof (SINGLE_SETTING_PROVIDER_START) - 1)))
     {
       continue;

--- a/SetupDataPkg/Include/Library/ConfigDataLib.h
+++ b/SetupDataPkg/Include/Library/ConfigDataLib.h
@@ -35,6 +35,7 @@
 #define DFCI_OEM_SETTING_ID__CONF         "Device.ConfigData.ConfigData"
 #define SINGLE_SETTING_PROVIDER_START     "Device.ConfigData.TagID_"
 #define SINGLE_SETTING_PROVIDER_TEMPLATE  "Device.ConfigData.TagID_%08X"
+#define DFCI_OEM_SETTING_ID__RUNTIMECONF  "Device.RuntimeData.RuntimeData"
 
 typedef struct {
   UINT16    PlatformId;


### PR DESCRIPTION
Have ConfApp pass Runtime settings to DFCI to be passed to a settings provider.