### PR TITLE
Removed the platform supplied GUID with hardcoded GUID

### DIFF
--- a/SetupDataPkg/ConfApp/ConfApp.inf
+++ b/SetupDataPkg/ConfApp/ConfApp.inf
@@ -60,14 +60,12 @@
   ConfigDataLib
   PerformanceLib
 
-[Pcd]
-  gSetupDataPkgTokenSpaceGuid.PcdConfigPolicyVariableGuid
-
 [Guids]
   gDfciAuthProvisionVarNamespace
   gDfciPermissionManagerVarNamespace
   gDfciSettingsManagerVarNamespace
   gMuVarPolicyDxePhaseGuid
+  gSetupConfigPolicyVariableGuid
 
 [Protocols]
   gEfiSimpleTextInputExProtocolGuid

--- a/SetupDataPkg/ConfApp/UnitTest/ConfAppBootOptionUnitTest.inf
+++ b/SetupDataPkg/ConfApp/UnitTest/ConfAppBootOptionUnitTest.inf
@@ -52,5 +52,5 @@
   gDfciAuthenticationProtocolGuid
   gEfiSimpleTextInputExProtocolGuid
 
-[Pcd]
-  gSetupDataPkgTokenSpaceGuid.PcdConfigPolicyVariableGuid
+[Guids]
+  gSetupConfigPolicyVariableGuid

--- a/SetupDataPkg/ConfApp/UnitTest/ConfAppSecureBootUnitTest.inf
+++ b/SetupDataPkg/ConfApp/UnitTest/ConfAppSecureBootUnitTest.inf
@@ -54,6 +54,3 @@
   gDfciSettingAccessProtocolGuid
   gDfciAuthenticationProtocolGuid
   gEfiSimpleTextInputExProtocolGuid
-
-[Pcd]
-  gSetupDataPkgTokenSpaceGuid.PcdConfigPolicyVariableGuid

--- a/SetupDataPkg/ConfApp/UnitTest/ConfAppSetupConfUnitTest.inf
+++ b/SetupDataPkg/ConfApp/UnitTest/ConfAppSetupConfUnitTest.inf
@@ -61,5 +61,5 @@
   gEfiUsbIoProtocolGuid
   gEfiBlockIoProtocolGuid
 
-[Pcd]
-  gSetupDataPkgTokenSpaceGuid.PcdConfigPolicyVariableGuid
+[Guids]
+  gSetupConfigPolicyVariableGuid

--- a/SetupDataPkg/ConfApp/UnitTest/ConfAppSysInfoUnitTest.inf
+++ b/SetupDataPkg/ConfApp/UnitTest/ConfAppSysInfoUnitTest.inf
@@ -54,5 +54,5 @@
   gEfiSimpleTextInputExProtocolGuid
   gEfiFirmwareManagementProtocolGuid
 
-[Pcd]
-  gSetupDataPkgTokenSpaceGuid.PcdConfigPolicyVariableGuid
+[Guids]
+  gSetupConfigPolicyVariableGuid

--- a/SetupDataPkg/ConfApp/UnitTest/ConfAppUnitTest.inf
+++ b/SetupDataPkg/ConfApp/UnitTest/ConfAppUnitTest.inf
@@ -49,5 +49,5 @@
   gDfciAuthenticationProtocolGuid
   gEfiSimpleTextInputExProtocolGuid
 
-[Pcd]
-  gSetupDataPkgTokenSpaceGuid.PcdConfigPolicyVariableGuid
+[Guids]
+  gSetupConfigPolicyVariableGuid

--- a/SetupDataPkg/ConfDataSettingProvider/ConfDataSettingProvider.c
+++ b/SetupDataPkg/ConfDataSettingProvider/ConfDataSettingProvider.c
@@ -55,7 +55,7 @@ GetDefaultConfigDataBin (
 
   // Then populate the slot with default one from FV.
   Status = GetSectionFromAnyFv (
-             PcdGetPtr (PcdConfigPolicyVariableGuid),
+             &gSetupConfigPolicyVariableGuid,
              EFI_SECTION_RAW,
              0,
              (VOID **)&Data,
@@ -179,7 +179,7 @@ SetSingleConfigData (
 
   UnicodeSPrintAsciiFormat (TempUnicodeId, Size * 2, SINGLE_SETTING_PROVIDER_TEMPLATE, Tag);
 
-  Status = gRT->SetVariable (TempUnicodeId, PcdGetPtr (PcdConfigPolicyVariableGuid), CDATA_NV_VAR_ATTR, BufferSize, Buffer);
+  Status = gRT->SetVariable (TempUnicodeId, &gSetupConfigPolicyVariableGuid, CDATA_NV_VAR_ATTR, BufferSize, Buffer);
 
 Exit:
   if (TempUnicodeId != NULL) {
@@ -609,7 +609,7 @@ SingleConfDataSetDefault (
 
   Status = gRT->SetVariable (
                   VarName,
-                  PcdGetPtr (PcdConfigPolicyVariableGuid),
+                  &gSetupConfigPolicyVariableGuid,
                   CDATA_NV_VAR_ATTR,
                   (TagHdrBuffer->Length<<2) - sizeof (*TagHdrBuffer) - sizeof (CDATA_COND) * TagHdrBuffer->ConditionNum,
                   TagBuffer
@@ -760,7 +760,7 @@ SingleConfDataSet (
   AsciiStrToUnicodeStrS (This->Id, VarName, Size + 1);
 
   // Now set it to non-volatile variable
-  Status = gRT->SetVariable (VarName, PcdGetPtr (PcdConfigPolicyVariableGuid), CDATA_NV_VAR_ATTR, ValueSize, (VOID *)Value);
+  Status = gRT->SetVariable (VarName, &gSetupConfigPolicyVariableGuid, CDATA_NV_VAR_ATTR, ValueSize, (VOID *)Value);
 
   if (!EFI_ERROR (Status)) {
     *Flags |= DFCI_SETTING_FLAGS_OUT_REBOOT_REQUIRED;
@@ -817,7 +817,7 @@ SingleConfDataGet (
 
   AsciiStrToUnicodeStrS (This->Id, VarName, Size + 1);
 
-  Status = gRT->GetVariable (VarName, PcdGetPtr (PcdConfigPolicyVariableGuid), NULL, ValueSize, (VOID *)Value);
+  Status = gRT->GetVariable (VarName, &gSetupConfigPolicyVariableGuid, NULL, ValueSize, (VOID *)Value);
 
 Done:
   if (VarName != NULL) {
@@ -891,9 +891,9 @@ RegisterSingleTag (
   AsciiStrToUnicodeStrS (TempAsciiId, TempUnicodeId, Size);
 
   Size   = 0;
-  Status = gRT->GetVariable (TempUnicodeId, PcdGetPtr (PcdConfigPolicyVariableGuid), NULL, &Size, NULL);
+  Status = gRT->GetVariable (TempUnicodeId, &gSetupConfigPolicyVariableGuid, NULL, &Size, NULL);
   if (Status == EFI_NOT_FOUND) {
-    Status = gRT->SetVariable (TempUnicodeId, PcdGetPtr (PcdConfigPolicyVariableGuid), CDATA_NV_VAR_ATTR, BufferSize, Buffer);
+    Status = gRT->SetVariable (TempUnicodeId, &gSetupConfigPolicyVariableGuid, CDATA_NV_VAR_ATTR, BufferSize, Buffer);
     if (EFI_ERROR (Status)) {
       DEBUG ((DEBUG_ERROR, "Initializing variable %s failed - %r.\n", TempUnicodeId, Status));
       goto Exit;
@@ -916,7 +916,7 @@ RegisterSingleTag (
 
   Status = RegisterVarStateVariablePolicy (
              mVariablePolicy,
-             PcdGetPtr (PcdConfigPolicyVariableGuid),
+             &gSetupConfigPolicyVariableGuid,
              TempUnicodeId,
              (UINT32)BufferSize,
              VARIABLE_POLICY_NO_MAX_SIZE,

--- a/SetupDataPkg/ConfDataSettingProvider/ConfDataSettingProvider.inf
+++ b/SetupDataPkg/ConfDataSettingProvider/ConfDataSettingProvider.inf
@@ -36,11 +36,9 @@
   ConfigBlobBaseLib
   VariablePolicyHelperLib
 
-[Pcd]
-  gSetupDataPkgTokenSpaceGuid.PcdConfigPolicyVariableGuid
-
 [Guids]
   gMuVarPolicyDxePhaseGuid
+  gSetupConfigPolicyVariableGuid
 
 [Protocols]
   gPolicyProtocolGuid

--- a/SetupDataPkg/ConfDataSettingProvider/UnitTest/ConfDataSettingProviderUnitTest.c
+++ b/SetupDataPkg/ConfDataSettingProvider/UnitTest/ConfDataSettingProviderUnitTest.c
@@ -118,7 +118,7 @@ GetSectionFromAnyFv (
 {
   VOID  *ret_buf;
 
-  assert_memory_equal (NameGuid, PcdGetPtr (PcdConfigPolicyVariableGuid), sizeof (EFI_GUID));
+  assert_memory_equal (NameGuid, &gSetupConfigPolicyVariableGuid, sizeof (EFI_GUID));
   assert_int_equal (SectionType, EFI_SECTION_RAW);
   assert_non_null (Buffer);
   assert_non_null (Size);
@@ -231,7 +231,7 @@ RegisterVarStateVariablePolicy (
   )
 {
   DEBUG ((DEBUG_INFO, "%a Register for %s under %g\n", __FUNCTION__, Name, Namespace));
-  assert_ptr_equal (Namespace, PcdGetPtr (PcdConfigPolicyVariableGuid));
+  assert_ptr_equal (Namespace, &gSetupConfigPolicyVariableGuid);
   assert_int_equal (MaxSize, VARIABLE_POLICY_NO_MAX_SIZE);
   assert_int_equal (AttributesMustHave, CDATA_NV_VAR_ATTR);
   assert_int_equal (AttributesCantHave, (UINT32) ~CDATA_NV_VAR_ATTR);
@@ -283,7 +283,7 @@ MockGetVariable (
   VOID   *RetData;
 
   assert_non_null (VariableName);
-  assert_memory_equal (VendorGuid, PcdGetPtr (PcdConfigPolicyVariableGuid), sizeof (EFI_GUID));
+  assert_memory_equal (VendorGuid, &gSetupConfigPolicyVariableGuid, sizeof (EFI_GUID));
   assert_non_null (DataSize);
 
   DEBUG ((DEBUG_INFO, "%a Name: %s, GUID: %g, Size: %x\n", __FUNCTION__, VariableName, VendorGuid, *DataSize));

--- a/SetupDataPkg/ConfDataSettingProvider/UnitTest/ConfDataSettingProviderUnitTest.inf
+++ b/SetupDataPkg/ConfDataSettingProvider/UnitTest/ConfDataSettingProviderUnitTest.inf
@@ -48,6 +48,4 @@
 
 [Guids]
   gMuVarPolicyDxePhaseGuid
-
-[Pcd]
-  gSetupDataPkgTokenSpaceGuid.PcdConfigPolicyVariableGuid
+  gSetupConfigPolicyVariableGuid

--- a/SetupDataPkg/Docs/Overview/Overview.md
+++ b/SetupDataPkg/Docs/Overview/Overview.md
@@ -192,8 +192,8 @@ followed by a system reboot:
 
 | Variable Name | Variable GUID | Variable Attributes |
 | ------------ | ------------------ | ------------------|
-| `CONF_POLICY_BLOB` | `gSetupDataPkgTokenSpaceGuid.PcdConfigPolicyVariableGuid` | `EFI_VARIABLE_NON_VOLATILE + EFI_VARIABLE_BOOTSERVICE_ACCESS` |
-| `Device.ConfigData.TagID_%08X` | `gSetupDataPkgTokenSpaceGuid.PcdConfigPolicyVariableGuid` | `EFI_VARIABLE_NON_VOLATILE + EFI_VARIABLE_BOOTSERVICE_ACCESS` |
+| `CONF_POLICY_BLOB` | `gSetupConfigPolicyVariableGuid` | `EFI_VARIABLE_NON_VOLATILE + EFI_VARIABLE_BOOTSERVICE_ACCESS` |
+| `Device.ConfigData.TagID_%08X` | `gSetupConfigPolicyVariableGuid` | `EFI_VARIABLE_NON_VOLATILE + EFI_VARIABLE_BOOTSERVICE_ACCESS` |
 
 - Upon a new boot, entities other than UEFI can consume the aforementioned variable.
 - After entering UEFI firmware, platform policy module will pull previously stored configuration data variable from UEFI

--- a/SetupDataPkg/Docs/PlatformIntegration/PlatformIntegrationSteps.md
+++ b/SetupDataPkg/Docs/PlatformIntegration/PlatformIntegrationSteps.md
@@ -107,9 +107,6 @@ will omit the integration steps for these features. For more information about D
   # The GUID of SetupDataPkg/ConfApp/ConfApp.inf: E3624086-4FCD-446E-9D07-B6B913792071
   gEfiMdeModulePkgTokenSpaceGuid.PcdBootManagerMenuFile|{ 0x86, 0x40, 0x62, 0xe3, 0xcd, 0x4f, 0x6e, 0x44, 0x9d, 0x7, 0xb6, 0xb9, 0x13, 0x79, 0x20, 0x71 }
 
-  # The GUID for configuration setup blob, $(CONF_POLICY_GUID_BYTES) should be set during pre-build time
-  gSetupDataPkgTokenSpaceGuid.PcdConfigPolicyVariableGuid|$(CONF_POLICY_GUID_BYTES)
-
 [LibraryClasses]
   ConfigDataLib|SetupDataPkg/Library/ConfigDataLib/ConfigDataLib.inf
 

--- a/SetupDataPkg/SetupDataPkg.dec
+++ b/SetupDataPkg/SetupDataPkg.dec
@@ -27,16 +27,15 @@
 
 [Guids]
   gSetupDataPkgTokenSpaceGuid     = { 0x651d23a, 0xe244, 0x4a7f, { 0x8d, 0x2e, 0x37, 0xac, 0x2b, 0xf9, 0x32, 0xff } }
+  ## Configuration modules will locate variables under this GUID to initiate and/or update system configuration.
+  #
+  gSetupConfigPolicyVariableGuid  = { 0x7664559f, 0x829e, 0x48e8, { 0xa4, 0x73, 0xf1, 0x2a, 0xda, 0xd1, 0xdd, 0xd2 } }
 
 [Ppis]
 
 [Protocols]
 
 [PcdsFixedAtBuild]
-  ## The setup data variable GUID
-  # @Prompt Platform supplied GUID, configuration modules will locate variable under this GUID
-  #         to initiate and/or update system configuration.
-  gSetupDataPkgTokenSpaceGuid.PcdConfigPolicyVariableGuid|{0}|VOID*|0x00000001
 
 [PcdsDynamic, PcdsDynamicEx]
 


### PR DESCRIPTION
As an effort of conforming XML and YAML configurations, a predefined GUID is more feasible for the peripheral tools to streamline the binary generations and upper layer consumptions.

This change replaces "PcdConfigPolicyVariableGuid" with "gSetupConfigPolicyVariableGuid".