### PR TITLE
Fixing a truncated string output when trying to dump the current settings

### DIFF
--- a/SetupDataPkg/ConfApp/SetupConf.c
+++ b/SetupDataPkg/ConfApp/SetupConf.c
@@ -913,6 +913,7 @@ SetupConfMgr (
   CHAR8         *StrBuf;
   UINTN         StrBufSize;
   UINTN         Index;
+  UINTN         PrintedUnicodes;
 
   switch (mSetupConfState) {
     case SetupConfInit:
@@ -998,8 +999,14 @@ SetupConfMgr (
       } else {
         Print (L"\nCurrent configurations are dumped Below in format of *.SVD:\n");
         Print (L"\n");
-        for (Index = 0; Index < StrBufSize; Index ++) {
-          Print (L"%c", StrBuf[Index]);
+        Index = 0;
+        while (Index < StrBufSize) {
+          PrintedUnicodes = Print (L"%a", &StrBuf[Index]);
+          Index += PrintedUnicodes;
+          if (PrintedUnicodes == 0) {
+            // So that we will not get stuck if Print function malfunctions
+            break;
+          }
         }
         Print (L"\n");
       }

--- a/SetupDataPkg/ConfApp/SetupConf.c
+++ b/SetupDataPkg/ConfApp/SetupConf.c
@@ -913,7 +913,7 @@ SetupConfMgr (
   CHAR8         *StrBuf;
   UINTN         StrBufSize;
   UINTN         Index;
-  UINTN         PrintedUnicodes;
+  UINTN         PrintedUnicode;
 
   switch (mSetupConfState) {
     case SetupConfInit:
@@ -1001,13 +1001,14 @@ SetupConfMgr (
         Print (L"\n");
         Index = 0;
         while (Index < StrBufSize) {
-          PrintedUnicodes = Print (L"%a", &StrBuf[Index]);
-          Index += PrintedUnicodes;
-          if (PrintedUnicodes == 0) {
+          PrintedUnicode = Print (L"%a", &StrBuf[Index]);
+          Index         += PrintedUnicode;
+          if (PrintedUnicode == 0) {
             // So that we will not get stuck if Print function malfunctions
             break;
           }
         }
+
         Print (L"\n");
       }
 

--- a/SetupDataPkg/ConfApp/SetupConf.c
+++ b/SetupDataPkg/ConfApp/SetupConf.c
@@ -912,6 +912,7 @@ SetupConfMgr (
   EFI_KEY_DATA  KeyData;
   CHAR8         *StrBuf;
   UINTN         StrBufSize;
+  UINTN         Index;
 
   switch (mSetupConfState) {
     case SetupConfInit:
@@ -996,7 +997,11 @@ SetupConfMgr (
         Status = EFI_SUCCESS;
       } else {
         Print (L"\nCurrent configurations are dumped Below in format of *.SVD:\n");
-        Print (L"\n%a\n", StrBuf);
+        Print (L"\n");
+        for (Index = 0; Index < StrBufSize; Index ++) {
+          Print (L"%c", StrBuf[Index]);
+        }
+        Print (L"\n");
       }
 
       mSetupConfState = SetupConfDumpComplete;


### PR DESCRIPTION
The original implementation would rely on the printing stack to print the entire collected xml as string, which is truncated by the %a parser. This change fixed the issue by dumping the string in a loop till all characters are printed.