### PR TITLE
Supply unsigned xml based on system operation mode

### DIFF
--- a/SetupDataPkg/ConfDfciUnsignedListInit/ConfDfciUnsignedListInit.c
+++ b/SetupDataPkg/ConfDfciUnsignedListInit/ConfDfciUnsignedListInit.c
@@ -46,6 +46,7 @@ ConfDfciUnsignedListInitEntry (
     if (Size != sizeof (EFI_GUID)) {
       DEBUG ((DEBUG_ERROR, "%a Setting dynamic PCD returned with unexpected size 0x%x\n", __FUNCTION__));
       ASSERT (FALSE);
+      return EFI_ABORTED;
     }
   }
 

--- a/SetupDataPkg/ConfDfciUnsignedListInit/ConfDfciUnsignedListInit.c
+++ b/SetupDataPkg/ConfDfciUnsignedListInit/ConfDfciUnsignedListInit.c
@@ -14,8 +14,12 @@
 #include <Library/ConfigSystemModeLib.h>
 
 /**
-  This function initializes the DFCI unsigned XML PCD based on the system
-  operation mode.
+  This PEIM will update the PCD content based on the system operation mode,
+  before the DFCI has a chance to look at the file guid PCD. If this is MFG
+  mode, that means the unsigned settings will be accepted, thus the file GUID
+  PCD contains a legit value. Otherwise, it will be supplied with a bogus/null
+  value so that DFCI will not be able to locate any xml and eventually not
+  taking any unsigned settings.
 
   @param  FileHandle  Handle of the file being invoked.
   @param  PeiServices Describes the list of possible PEI Services.

--- a/SetupDataPkg/ConfDfciUnsignedListInit/ConfDfciUnsignedListInit.c
+++ b/SetupDataPkg/ConfDfciUnsignedListInit/ConfDfciUnsignedListInit.c
@@ -25,7 +25,7 @@
 **/
 EFI_STATUS
 EFIAPI
-SgiPlatformPeim (
+_ConfDfciUnsignedListInitEntry (
  IN       EFI_PEI_FILE_HANDLE  FileHandle,
  IN CONST EFI_PEI_SERVICES     **PeiServices
   )

--- a/SetupDataPkg/ConfDfciUnsignedListInit/ConfDfciUnsignedListInit.c
+++ b/SetupDataPkg/ConfDfciUnsignedListInit/ConfDfciUnsignedListInit.c
@@ -26,8 +26,8 @@
 EFI_STATUS
 EFIAPI
 ConfDfciUnsignedListInitEntry (
- IN       EFI_PEI_FILE_HANDLE  FileHandle,
- IN CONST EFI_PEI_SERVICES     **PeiServices
+  IN       EFI_PEI_FILE_HANDLE  FileHandle,
+  IN CONST EFI_PEI_SERVICES     **PeiServices
   )
 {
   UINTN       Size;
@@ -35,7 +35,7 @@ ConfDfciUnsignedListInitEntry (
 
   if (!IsSystemInManufacturingMode ()) {
     // Invalidate the PCD if system operation does not allow it.
-    Size = sizeof (EFI_GUID);
+    Size   = sizeof (EFI_GUID);
     Status = PcdSetPtrS (PcdUnsignedPermissionsFile, &Size, &gZeroGuid);
     if (EFI_ERROR (Status)) {
       DEBUG ((DEBUG_ERROR, "%a Setting dynamic PCD failed %r\n", __FUNCTION__, Status));

--- a/SetupDataPkg/ConfDfciUnsignedListInit/ConfDfciUnsignedListInit.c
+++ b/SetupDataPkg/ConfDfciUnsignedListInit/ConfDfciUnsignedListInit.c
@@ -44,7 +44,7 @@ ConfDfciUnsignedListInitEntry (
     }
 
     if (Size != sizeof (EFI_GUID)) {
-      DEBUG ((DEBUG_ERROR, "%a Setting dynamic PCD returned with unexpected size 0x%x\n", __FUNCTION__));
+      DEBUG ((DEBUG_ERROR, "%a Setting dynamic PCD returned with unexpected size 0x%x\n", __FUNCTION__, Size));
       ASSERT (FALSE);
       return EFI_ABORTED;
     }

--- a/SetupDataPkg/ConfDfciUnsignedListInit/ConfDfciUnsignedListInit.c
+++ b/SetupDataPkg/ConfDfciUnsignedListInit/ConfDfciUnsignedListInit.c
@@ -1,0 +1,39 @@
+/** @file
+  Settings provider driver to register configuration data setter and getters.
+
+  Copyright (c) 2017 - 2020, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) Microsoft Corporation.
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#include <PiPei.h>
+
+#include <Guid/ZeroGuid.h>
+
+#include <Library/PcdLib.h>
+#include <Library/ConfigSystemModeLib.h>
+
+/**
+  This function initializes the DFCI unsigned XML PCD based on the system
+  operation mode.
+
+  @param  FileHandle  Handle of the file being invoked.
+  @param  PeiServices Describes the list of possible PEI Services.
+
+  @retval  EFI_SUCCESS   The PEIM executed normally.
+  @retval  !EFI_SUCCESS  The PEIM failed to execute normally.
+**/
+EFI_STATUS
+EFIAPI
+SgiPlatformPeim (
+ IN       EFI_PEI_FILE_HANDLE  FileHandle,
+ IN CONST EFI_PEI_SERVICES     **PeiServices
+  )
+{
+  if (!IsSystemInManufacturingMode ()) {
+    // Invalidate the PCD if system operation does not allow it.
+    PcdSetPtrS (PcdUnsignedPermissionsFile, sizeof (EFI_GUID), &gZeroGuid);
+  }
+
+  return EFI_SUCCESS;
+}

--- a/SetupDataPkg/ConfDfciUnsignedListInit/ConfDfciUnsignedListInit.c
+++ b/SetupDataPkg/ConfDfciUnsignedListInit/ConfDfciUnsignedListInit.c
@@ -25,7 +25,7 @@
 **/
 EFI_STATUS
 EFIAPI
-_ConfDfciUnsignedListInitEntry (
+ConfDfciUnsignedListInitEntry (
  IN       EFI_PEI_FILE_HANDLE  FileHandle,
  IN CONST EFI_PEI_SERVICES     **PeiServices
   )

--- a/SetupDataPkg/ConfDfciUnsignedListInit/ConfDfciUnsignedListInit.inf
+++ b/SetupDataPkg/ConfDfciUnsignedListInit/ConfDfciUnsignedListInit.inf
@@ -27,5 +27,5 @@
   PeimEntryPoint
   ConfigSystemModeLib
 
-[Pcds]
+[Pcd]
   gDfciPkgTokenSpaceGuid.PcdUnsignedPermissionsFile

--- a/SetupDataPkg/ConfDfciUnsignedListInit/ConfDfciUnsignedListInit.inf
+++ b/SetupDataPkg/ConfDfciUnsignedListInit/ConfDfciUnsignedListInit.inf
@@ -1,0 +1,31 @@
+## @file
+# Initialize DFCI unsigned list.
+#
+# Copyright (C) Microsoft Corporation.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+[Defines]
+  INF_VERSION         = 0x00010017
+  BASE_NAME           = ConfDfciUnsignedListInit
+  FILE_GUID           = 49F3C599-D84C-4E49-BBB6-8FF9A1EE5148
+  VERSION_STRING      = 1.0
+  MODULE_TYPE         = PEIM
+  ENTRY_POINT         = ConfDfciUnsignedListInitEntry
+
+[Sources]
+  ConfDfciUnsignedListInit.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  DfciPkg/DfciPkg.dec
+  SetupDataPkg/SetupDataPkg.dec
+
+[LibraryClasses]
+  PcdLib
+  PeimEntryPoint
+  ConfigSystemModeLib
+
+[Pcds]
+  gDfciPkgTokenSpaceGuid.PcdUnsignedPermissionsFile

--- a/SetupDataPkg/ConfDfciUnsignedListInit/ConfDfciUnsignedListInit.inf
+++ b/SetupDataPkg/ConfDfciUnsignedListInit/ConfDfciUnsignedListInit.inf
@@ -27,6 +27,7 @@
   PcdLib
   PeimEntryPoint
   ConfigSystemModeLib
+  DebugLib
 
 [Guids]
   gZeroGuid

--- a/SetupDataPkg/ConfDfciUnsignedListInit/ConfDfciUnsignedListInit.inf
+++ b/SetupDataPkg/ConfDfciUnsignedListInit/ConfDfciUnsignedListInit.inf
@@ -19,6 +19,7 @@
 
 [Packages]
   MdePkg/MdePkg.dec
+  MdeModulePkg/MdeModulePkg.dec
   DfciPkg/DfciPkg.dec
   SetupDataPkg/SetupDataPkg.dec
 
@@ -26,6 +27,9 @@
   PcdLib
   PeimEntryPoint
   ConfigSystemModeLib
+
+[Guids]
+  gZeroGuid
 
 [Pcd]
   gDfciPkgTokenSpaceGuid.PcdUnsignedPermissionsFile

--- a/SetupDataPkg/ConfDfciUnsignedListInit/ConfDfciUnsignedListInit.inf
+++ b/SetupDataPkg/ConfDfciUnsignedListInit/ConfDfciUnsignedListInit.inf
@@ -29,3 +29,6 @@
 
 [Pcd]
   gDfciPkgTokenSpaceGuid.PcdUnsignedPermissionsFile
+
+[Depex]
+  TRUE

--- a/SetupDataPkg/SetupDataPkg.dsc
+++ b/SetupDataPkg/SetupDataPkg.dsc
@@ -74,6 +74,10 @@
 [LibraryClasses.common.UEFI_APPLICATION]
   UefiApplicationEntryPoint|MdePkg/Library/UefiApplicationEntryPoint/UefiApplicationEntryPoint.inf
 
+[PcdsDynamicExDefault]
+  # Set a default value for such dynamic PCD
+  gDfciPkgTokenSpaceGuid.PcdUnsignedPermissionsFile|{GUID("62CF29AD-FEEE-4930-B71B-4806C787C6AA")}
+
 [Components]
   SetupDataPkg/Library/ConfigDataLib/ConfigDataLib.inf
   SetupDataPkg/Library/ConfigBlobBaseLib/ConfigBlobBaseLib.inf

--- a/SetupDataPkg/SetupDataPkg.dsc
+++ b/SetupDataPkg/SetupDataPkg.dsc
@@ -81,6 +81,7 @@
   SetupDataPkg/Library/ConfigVariableListLibNull/ConfigVariableListLibNull.inf
   SetupDataPkg/Library/ConfigSystemModeLibNull/ConfigSystemModeLibNull.inf
 
+  SetupDataPkg/ConfDfciUnsignedListInit/ConfDfciUnsignedListInit.inf
   SetupDataPkg/ConfDataSettingProvider/ConfDataSettingProvider.inf
 
 [Components.X64, Components.AARCH64]

--- a/mu_plus_ext_dep.yaml
+++ b/mu_plus_ext_dep.yaml
@@ -9,6 +9,6 @@
   "name": "MU_PLUS",
   "var_name": "MU_PLUS_PATH",
   "source": "https://github.com/microsoft/mu_plus.git",
-  "version": "2c3d107e9ad7f91a4461c5799e28d8cf2394a0fd", # release/202202
+  "version": "7f74fbf7698b9b5698a520aee1003bb409bfc613", # release/202202
   "flags": ["set_build_var"]
 }


### PR DESCRIPTION
This change will change the DFCI unsigned setting's XML file GUID based on the current system mode. Such that on non-MFG mode, the DFCI will not accept unsigned settings. When the system is in MFG mode, the system will only block the settings listed in the XML file.