### PR TITLE
Added manufacturing mode check to not lock variables

### DIFF
--- a/SetupDataPkg/ConfDataSettingProvider/ConfDataSettingProvider.c
+++ b/SetupDataPkg/ConfDataSettingProvider/ConfDataSettingProvider.c
@@ -508,6 +508,12 @@ RegisterSingleConfigVariable (
     goto Exit;
   }
 
+  if (IsSystemInManufacturingMode ()) {
+    // As promised, configuration variables will not be protected under MFG mode. Thus branch to the wrap up logic.
+    DEBUG ((DEBUG_WARN, "%a System in manufacturing mode, not applying variable policies!\n", __FUNCTION__));
+    goto Exit;
+  }
+
   Status = RegisterVarStateVariablePolicy (
              mVariablePolicy,
              &VarListEntry->Guid,
@@ -591,12 +597,6 @@ SettingsProviderSupportProtocolNotify (
     // Should not be here, but...
     DEBUG ((DEBUG_ERROR, "%a Retrieved config data is NULL.\n", __FUNCTION__));
     Status = EFI_COMPROMISED_DATA;
-    goto Done;
-  }
-
-  if (IsSystemInManufacturingMode ()) {
-    // As promised, configuration variables will not be protected under MFG mode. Thus branch to the wrap up logic.
-    DEBUG ((DEBUG_WARN, "%a System in manufacturing mode, not applying variable policies!\n", __FUNCTION__));
     goto Done;
   }
 

--- a/SetupDataPkg/ConfDataSettingProvider/ConfDataSettingProvider.c
+++ b/SetupDataPkg/ConfDataSettingProvider/ConfDataSettingProvider.c
@@ -594,6 +594,11 @@ SettingsProviderSupportProtocolNotify (
     goto Done;
   }
 
+  if (IsSystemInManufacturingMode ()) {
+    // As promised, configuration variables will not be protected under MFG mode. Thus branch to the wrap up logic.
+    goto Done;
+  }
+
   for (Index = 0; Index < VarListCount; Index++) {
     // Using default blob to initialize individual setting providers
     Status = RegisterSingleConfigVariable (&VarList[Index]);

--- a/SetupDataPkg/ConfDataSettingProvider/ConfDataSettingProvider.c
+++ b/SetupDataPkg/ConfDataSettingProvider/ConfDataSettingProvider.c
@@ -28,6 +28,7 @@
 #include <Library/VariablePolicyHelperLib.h>
 #include <Library/SafeIntLib.h>
 #include <Library/ConfigVariableListLib.h>
+#include <Library/ConfigSystemModeLib.h>
 
 DFCI_SETTING_PROVIDER_SUPPORT_PROTOCOL  *mSettingProviderProtocol = NULL;
 EDKII_VARIABLE_POLICY_PROTOCOL          *mVariablePolicy          = NULL;

--- a/SetupDataPkg/ConfDataSettingProvider/ConfDataSettingProvider.c
+++ b/SetupDataPkg/ConfDataSettingProvider/ConfDataSettingProvider.c
@@ -596,6 +596,7 @@ SettingsProviderSupportProtocolNotify (
 
   if (IsSystemInManufacturingMode ()) {
     // As promised, configuration variables will not be protected under MFG mode. Thus branch to the wrap up logic.
+    DEBUG ((DEBUG_WARN, "%a System in manufacturing mode, not applying variable policies!\n", __FUNCTION__));
     goto Done;
   }
 

--- a/SetupDataPkg/ConfDataSettingProvider/ConfDataSettingProvider.inf
+++ b/SetupDataPkg/ConfDataSettingProvider/ConfDataSettingProvider.inf
@@ -37,6 +37,7 @@
   VariablePolicyHelperLib
   SafeIntLib
   ConfigVariableListLib
+  ConfigSystemModeLib
 
 [Guids]
   gMuVarPolicyDxePhaseGuid

--- a/SetupDataPkg/ConfDataSettingProvider/UnitTest/ConfDataSettingProviderUnitTest.inf
+++ b/SetupDataPkg/ConfDataSettingProvider/UnitTest/ConfDataSettingProviderUnitTest.inf
@@ -43,6 +43,7 @@
   PrintLib
   SafeIntLib
   ConfigVariableListLib
+  ConfigSystemModeLib
 
 [Protocols]
   gEdkiiVariablePolicyProtocolGuid


### PR DESCRIPTION
This change adds a check for system manufacturing mode and will not register for variable policies if so. This is to comply with the design of "profile and operation mode" contract.