### PR TITLE
Remove unnecessary dependencies

### DIFF
--- a/SetupDataPkg/ConfApp/ConfApp.inf
+++ b/SetupDataPkg/ConfApp/ConfApp.inf
@@ -35,7 +35,6 @@
   DfciPkg/DfciPkg.dec
   MsCorePkg/MsCorePkg.dec
   XmlSupportPkg/XmlSupportPkg.dec
-  PolicyServicePkg/PolicyServicePkg.dec
   SecurityPkg/SecurityPkg.dec
 
 [LibraryClasses]

--- a/SetupDataPkg/ConfApp/ConfApp.inf
+++ b/SetupDataPkg/ConfApp/ConfApp.inf
@@ -37,7 +37,6 @@
   XmlSupportPkg/XmlSupportPkg.dec
   PolicyServicePkg/PolicyServicePkg.dec
   SecurityPkg/SecurityPkg.dec
-  FmpDevicePkg/FmpDevicePkg.dec
 
 [LibraryClasses]
   BaseLib

--- a/SetupDataPkg/ConfApp/SystemInfo.c
+++ b/SetupDataPkg/ConfApp/SystemInfo.c
@@ -7,6 +7,7 @@
 **/
 
 #include <Uefi.h>
+#include <Protocol/FirmwareManagement.h>
 #include <Library/DebugLib.h>
 #include <Library/PcdLib.h>
 #include <Library/PrintLib.h>
@@ -16,7 +17,6 @@
 #include <Library/MuUefiVersionLib.h>
 #include <Library/UefiLib.h>
 #include <Library/ConfigDataLib.h>
-#include <Library/FmpDeviceLib.h>
 
 #include "ConfApp.h"
 

--- a/SetupDataPkg/ConfApp/UnitTest/ConfAppSysInfoUnitTest.inf
+++ b/SetupDataPkg/ConfApp/UnitTest/ConfAppSysInfoUnitTest.inf
@@ -34,7 +34,6 @@
   PcBdsPkg/PcBdsPkg.dec
   SecurityPkg/SecurityPkg.dec
   SetupDataPkg/SetupDataPkg.dec
-  FmpDevicePkg/FmpDevicePkg.dec
 
 [LibraryClasses]
   UefiBootServicesTableLib

--- a/SetupDataPkg/ConfDataSettingProvider/ConfDataSettingProvider.c
+++ b/SetupDataPkg/ConfDataSettingProvider/ConfDataSettingProvider.c
@@ -28,7 +28,6 @@
 #include <Library/VariablePolicyHelperLib.h>
 #include <Library/SafeIntLib.h>
 #include <Library/ConfigVariableListLib.h>
-#include <Library/ConfigSystemModeLib.h>
 
 DFCI_SETTING_PROVIDER_SUPPORT_PROTOCOL  *mSettingProviderProtocol = NULL;
 EDKII_VARIABLE_POLICY_PROTOCOL          *mVariablePolicy          = NULL;
@@ -506,12 +505,6 @@ RegisterSingleConfigVariable (
   } else {
     DEBUG ((DEBUG_ERROR, "Unexpected result from GetVariable - %r.\n", Status));
     Status = EFI_DEVICE_ERROR;
-    goto Exit;
-  }
-
-  if (IsSystemInManufacturingMode ()) {
-    // As promised, configuration variables will not be protected under MFG mode. Thus branch to the wrap up logic.
-    DEBUG ((DEBUG_WARN, "%a System in manufacturing mode, not applying variable policies!\n", __FUNCTION__));
     goto Exit;
   }
 

--- a/SetupDataPkg/ConfDataSettingProvider/ConfDataSettingProvider.inf
+++ b/SetupDataPkg/ConfDataSettingProvider/ConfDataSettingProvider.inf
@@ -42,7 +42,6 @@
   gSetupConfigPolicyVariableGuid
 
 [Protocols]
-  gPolicyProtocolGuid
   gDfciSettingsProviderSupportProtocolGuid
   gEdkiiVariablePolicyProtocolGuid
 

--- a/SetupDataPkg/ConfDataSettingProvider/ConfDataSettingProvider.inf
+++ b/SetupDataPkg/ConfDataSettingProvider/ConfDataSettingProvider.inf
@@ -21,7 +21,6 @@
   MdePkg/MdePkg.dec
   MdeModulePkg/MdeModulePkg.dec
   DfciPkg/DfciPkg.dec
-  PolicyServicePkg/PolicyServicePkg.dec
   SetupDataPkg/SetupDataPkg.dec
   MsCorePkg/MsCorePkg.dec
 

--- a/SetupDataPkg/ConfDataSettingProvider/ConfDataSettingProvider.inf
+++ b/SetupDataPkg/ConfDataSettingProvider/ConfDataSettingProvider.inf
@@ -37,7 +37,6 @@
   VariablePolicyHelperLib
   SafeIntLib
   ConfigVariableListLib
-  ConfigSystemModeLib
 
 [Guids]
   gMuVarPolicyDxePhaseGuid

--- a/SetupDataPkg/ConfDataSettingProvider/UnitTest/ConfDataSettingProviderUnitTest.c
+++ b/SetupDataPkg/ConfDataSettingProvider/UnitTest/ConfDataSettingProviderUnitTest.c
@@ -1145,7 +1145,6 @@ SettingsProviderNotifyShouldComplete (
     expect_string (MockDfciRegisterProvider, Provider->Id, ComparePtr[Index]);
     expect_memory (MockGetVariable, VariableName, Ctx->VarListPtr[Index].Name, SINGLE_CONF_DATA_ID_LEN * sizeof (CHAR16));
     will_return (MockGetVariable, mKnownGoodTags[Index].DataSize);
-    will_return (IsSystemInManufacturingMode, FALSE);
     expect_memory (RegisterVarStateVariablePolicy, Name, Ctx->VarListPtr[Index].Name, SINGLE_CONF_DATA_ID_LEN * sizeof (CHAR16));
     expect_value (RegisterVarStateVariablePolicy, MinSize, mKnownGoodTags[Index].DataSize);
     expect_value (RegisterVarStateVariablePolicy, AttributesMustHave, CDATA_NV_VAR_ATTR);
@@ -1164,7 +1163,6 @@ SettingsProviderNotifyShouldComplete (
   expect_value (MockSetVariable, DataSize, mKnownGoodTags[Index].DataSize);
   expect_memory (MockSetVariable, Data, mKnownGoodTags[Index].Data, mKnownGoodTags[Index].DataSize);
   will_return (MockSetVariable, EFI_SUCCESS);
-  will_return (IsSystemInManufacturingMode, FALSE);
   expect_memory (RegisterVarStateVariablePolicy, Name, Ctx->VarListPtr[Index].Name, SINGLE_CONF_DATA_ID_LEN * sizeof (CHAR16));
   expect_value (RegisterVarStateVariablePolicy, MinSize, mKnownGoodTags[Index].DataSize);
   expect_value (RegisterVarStateVariablePolicy, AttributesMustHave, CDATA_NV_VAR_ATTR);
@@ -1175,7 +1173,6 @@ SettingsProviderNotifyShouldComplete (
     expect_string (MockDfciRegisterProvider, Provider->Id, ComparePtr[Index + KNOWN_GOOD_TAG_COUNT]);
     expect_memory (MockGetVariable, VariableName, Ctx->VarListPtr[Index + KNOWN_GOOD_TAG_COUNT].Name, mKnownGoodRuntimeVars[Index].NameSize * sizeof (CHAR16));
     will_return (MockGetVariable, mKnownGoodRuntimeVars[Index].DataSize);
-    will_return (IsSystemInManufacturingMode, FALSE);
     expect_memory (RegisterVarStateVariablePolicy, Name, Ctx->VarListPtr[Index + KNOWN_GOOD_TAG_COUNT].Name, mKnownGoodRuntimeVars[Index].NameSize * sizeof (CHAR16));
     expect_value (RegisterVarStateVariablePolicy, MinSize, mKnownGoodRuntimeVars[Index].DataSize);
     expect_value (RegisterVarStateVariablePolicy, AttributesMustHave, (CDATA_NV_VAR_ATTR | EFI_VARIABLE_RUNTIME_ACCESS));
@@ -1185,65 +1182,6 @@ SettingsProviderNotifyShouldComplete (
 
   Index = 0;
   while (Index < KNOWN_GOOD_TAG_COUNT + KNOWN_GOOD_RUNTIME_VAR_COUNT) {
-    FreePool (ComparePtr[Index]);
-    Index++;
-  }
-
-  return UNIT_TEST_PASSED;
-}
-
-/**
-  Unit test for SettingsProviderSupportProtocolNotify of ConfDataSettingProvider.
-
-  @param[in]  Context    [Optional] An optional parameter that enables:
-                         1) test-case reuse with varied parameters and
-                         2) test-case re-entry for Target tests that need a
-                         reboot.  This parameter is a VOID* and it is the
-                         responsibility of the test author to ensure that the
-                         contents are well understood by all test cases that may
-                         consume it.
-
-  @retval  UNIT_TEST_PASSED             The Unit test has completed and the test
-                                        case was successful.
-  @retval  UNIT_TEST_ERROR_TEST_FAILED  A test case assertion has failed.
-**/
-UNIT_TEST_STATUS
-EFIAPI
-SettingsProviderNotifyInMfgShouldComplete (
-  IN UNIT_TEST_CONTEXT  Context
-  )
-{
-  CHAR8         *ComparePtr[KNOWN_GOOD_TAG_COUNT];
-  UINTN         Index = 0;
-  CONTEXT_DATA  *Ctx;
-
-  UT_ASSERT_NOT_NULL (Context);
-  Ctx = (CONTEXT_DATA *)Context;
-  UT_ASSERT_EQUAL (Ctx->VarListCnt, KNOWN_GOOD_TAG_COUNT + KNOWN_GOOD_RUNTIME_VAR_COUNT);
-
-  expect_value (MockLocateProtocol, Protocol, &gDfciSettingsProviderSupportProtocolGuid);
-  will_return (MockLocateProtocol, &mMockDfciSetting);
-
-  expect_value (MockLocateProtocol, Protocol, &gEdkiiVariablePolicyProtocolGuid);
-  will_return (MockLocateProtocol, &mMockDfciSetting);
-
-  will_return (RetrieveActiveConfigVarList, Ctx->VarListPtr);
-  will_return (RetrieveActiveConfigVarList, KNOWN_GOOD_TAG_COUNT);
-  will_return (RetrieveActiveConfigVarList, EFI_SUCCESS);
-
-  for (Index = 0; Index < KNOWN_GOOD_TAG_COUNT; Index++) {
-    ComparePtr[Index] = AllocatePool (SINGLE_CONF_DATA_ID_LEN);
-    AsciiSPrint (ComparePtr[Index], SINGLE_CONF_DATA_ID_LEN, SINGLE_SETTING_PROVIDER_TEMPLATE, mKnownGoodTags[Index].Tag);
-    expect_string (MockDfciRegisterProvider, Provider->Id, ComparePtr[Index]);
-    expect_memory (MockGetVariable, VariableName, Ctx->VarListPtr[Index].Name, SINGLE_CONF_DATA_ID_LEN * sizeof (CHAR16));
-    will_return (MockGetVariable, mKnownGoodTags[Index].DataSize);
-    will_return (IsSystemInManufacturingMode, TRUE);
-  }
-
-  SettingsProviderSupportProtocolNotify (NULL, NULL);
-
-  Index = 0;
-  while (Index < KNOWN_GOOD_TAG_COUNT) {
     FreePool (ComparePtr[Index]);
     Index++;
   }
@@ -1314,7 +1252,6 @@ UnitTestingEntry (
   // --------------Suite-----------Description--------------Name----------Function--------Pre---Post-------------------Context-----------
   //
   AddTestCase (MiscTests, "Protocol notify routine should succeed", "ProtocolNotify", SettingsProviderNotifyShouldComplete, ConfSettingProviderPrerequisite, NULL, &Context);
-  AddTestCase (MiscTests, "Protocol notify routine in MFG mode should succeed", "ProtocolNotify", SettingsProviderNotifyInMfgShouldComplete, ConfSettingProviderPrerequisite, NULL, &Context);
 
   AddTestCase (SingleSettingTests, "Get Single ConfData Default should return full blob", "SingleGetFullDefaultNormal", SingleConfDataGetDefaultNormal, ConfSettingProviderPrerequisite, NULL, &Context);
   AddTestCase (SingleSettingTests, "Get Single ConfData Default should fail with null provider", "SingleGetFullDefaultNull", SingleConfDataGetDefaultNull, NULL, NULL, NULL);

--- a/SetupDataPkg/ConfDataSettingProvider/UnitTest/ConfDataSettingProviderUnitTest.inf
+++ b/SetupDataPkg/ConfDataSettingProvider/UnitTest/ConfDataSettingProviderUnitTest.inf
@@ -43,7 +43,6 @@
   PrintLib
   SafeIntLib
   ConfigVariableListLib
-  ConfigSystemModeLib
 
 [Protocols]
   gEdkiiVariablePolicyProtocolGuid

--- a/SetupDataPkg/Library/ConfigBlobBaseLib/ConfigBlobBaseLib.inf
+++ b/SetupDataPkg/Library/ConfigBlobBaseLib/ConfigBlobBaseLib.inf
@@ -26,7 +26,6 @@
 [Packages]
   MdePkg/MdePkg.dec
   SetupDataPkg/SetupDataPkg.dec
-  PolicyServicePkg/PolicyServicePkg.dec
 
 [LibraryClasses]
   BaseLib

--- a/SetupDataPkg/SetupDataPkg.ci.yaml
+++ b/SetupDataPkg/SetupDataPkg.ci.yaml
@@ -40,7 +40,6 @@
             "PcBdsPkg/PcBdsPkg.dec",
             "XmlSupportPkg/XmlSupportPkg.dec",
             "SecurityPkg/SecurityPkg.dec",
-            "FmpDevicePkg/FmpDevicePkg.dec",
             "SetupDataPkg/SetupDataPkg.dec"
         ],
         # For host based unit tests

--- a/SetupDataPkg/SetupDataPkg.ci.yaml
+++ b/SetupDataPkg/SetupDataPkg.ci.yaml
@@ -34,7 +34,6 @@
         "AcceptableDependencies": [
             "MdePkg/MdePkg.dec",
             "MdeModulePkg/MdeModulePkg.dec",
-            "PolicyServicePkg/PolicyServicePkg.dec",
             "MsCorePkg/MsCorePkg.dec",
             "DfciPkg/DfciPkg.dec",
             "PcBdsPkg/PcBdsPkg.dec",


### PR DESCRIPTION
This change removed certain unnecessary dependencies from SetupDataPkg (including FmpPkg, PolicyServicesPkg) to make the package more platform agnostic.

Additionally, this change reverted the check of MFG mode in the settings provider driver. The expectation is that platforms will disable variable policy during MFG mode and variable policy will essentially be no-op.