### PR TITLE
Support ConfigEditor Loading Full DmpStore Blob

### DIFF
--- a/SetupDataPkg/Tools/ConfigEditor.py
+++ b/SetupDataPkg/Tools/ConfigEditor.py
@@ -741,7 +741,7 @@ class application(tkinter.Frame):
             if "dlt" in ftype or 'csv' in ftype:
                 question = ""
             elif ftype == "bin":
-                question = 'All configuration will be reloaded from binary blob, continue ?'
+                question = ''
             elif ftype == 'svd':
                 question = ''
             elif 'yaml' in ftype or 'yml' in ftype or 'xml' in ftype:
@@ -842,15 +842,6 @@ class application(tkinter.Frame):
     def load_bin_file(self, path):
         with open(path, "rb") as fd:
             bin_data = bytearray(fd.read())
-        bin_len = 0
-        for idx in self.cfg_data_list:
-            bin_len += len(self.cfg_data_list[idx].org_cfg_data_bin)
-
-        if len(bin_data) < bin_len:
-            messagebox.showerror(
-                "Binary file size is smaller than what YAML requires !"
-            )
-            return
 
         try:
             for idx in self.cfg_data_list:

--- a/SetupDataPkg/Tools/GenNCCfgData.py
+++ b/SetupDataPkg/Tools/GenNCCfgData.py
@@ -228,8 +228,8 @@ class CGenNCCfgData:
         xml_list = []
 
         # ensure that read in variables are part of schema, otherwise ignore them
-        loaded_barray = self.generate_binary_array(True)
-        loaded_vars = read_vlist_from_buffer(loaded_barray)
+        loaded_bytearray = self.generate_binary_array(True)
+        loaded_vars = read_vlist_from_buffer(loaded_bytearray)
         for var in var_list:
             for loaded_var in loaded_vars:
                 if (loaded_var.guid == var.guid and loaded_var.name == var.name):

--- a/SetupDataPkg/Tools/GenNCCfgData.py
+++ b/SetupDataPkg/Tools/GenNCCfgData.py
@@ -31,8 +31,6 @@ from VariableList import (
     get_delta_vlist
 )
 
-from GenCfgData import SETUP_CONFIG_POLICY_VAR_GUID
-
 
 class CGenNCCfgData:
     def __init__(self):

--- a/SetupDataPkg/Tools/GenNCCfgData.py
+++ b/SetupDataPkg/Tools/GenNCCfgData.py
@@ -228,10 +228,16 @@ class CGenNCCfgData:
     def load_default_from_bin(self, bin_data, is_variable_list_format):
         var_list = read_vlist_from_buffer(bin_data)
         xml_list = []
-        # YAML variables are included in list, XML tree should not process them
+
+        # ensure that read in variables are part of schema, otherwise ignore them
+        loaded_barray = self.generate_binary_array(True)
+        loaded_vars = read_vlist_from_buffer(loaded_barray)
         for var in var_list:
-            if str(var.guid).lower() != SETUP_CONFIG_POLICY_VAR_GUID.lower():
-                xml_list.append(var)
+            for loaded_var in loaded_vars:
+                if (loaded_var.guid == var.guid and loaded_var.name == var.name):
+                    xml_list.append(var)
+                    break
+
         uefi_variables_to_knobs(self.schema, xml_list)
         self.sync_shim_and_schema()
 


### PR DESCRIPTION
Load full variable list produced by dmpstore and ignore all variables that are not part of config.