### PR TITLE
Fixing an error for the python script processing struct array

### DIFF
--- a/SetupDataPkg/Tools/GenCfgData.py
+++ b/SetupDataPkg/Tools/GenCfgData.py
@@ -1411,16 +1411,33 @@ class CGenCfgData:
 
         if name is None:
             raise Exception("Can't find name of exec")
-        item = self.get_item_by_index(exec[name]["indx"])
-        itype = item["type"].split(",")[0]
-        if itype == "Combo":
-            # combo is an index into combo options
-            self.set_config_item_value(item, str(int.from_bytes(bin_data, "little")))
-        elif itype in ["EditNum", "EditText"]:
-            self.set_config_item_value(item, bin_data.decode())
-        elif itype in ["Table"]:
-            new_value = bytes_to_bracket_str(bin_data)
-            self.set_config_item_value(item, new_value)
+
+        # need to handle embedded structs case, where the indx is buried inside inner components
+        item = None
+        if "indx" in exec[name]:
+            item = self.get_item_by_index(exec[name]["indx"])
+            itype = item["type"].split(",")[0]
+            if itype == "Combo":
+                # combo is an index into combo options
+                self.set_config_item_value(item, str(int.from_bytes(bin_data, "little")))
+            elif itype in ["EditNum", "EditText"]:
+                self.set_config_item_value(item, bin_data.decode().rstrip('\0'))
+            elif itype in ["Table"]:
+                new_value = bytes_to_bracket_str(bin_data)
+                self.set_config_item_value(item, new_value)
+        else:
+            for each in exec[name]:
+                if "indx" in exec[name][each]:
+                    item = self.get_item_by_index(exec[name][each]["indx"])
+                    itype = item["type"].split(",")[0]
+                    if itype == "Combo":
+                        # combo is an index into combo options
+                        self.set_config_item_value(item, str(int.from_bytes(bin_data, "little")))
+                    elif itype in ["EditNum", "EditText"]:
+                        self.set_config_item_value(item, bin_data.decode())
+                    elif itype in ["Table"]:
+                        new_value = bytes_to_bracket_str(bin_data)
+                        self.set_config_item_value(item, new_value)
 
     def load_default_from_bin(self, bin_data, is_variable_list_format):
         # binary may be passed in variable list format or raw binary format

--- a/SetupDataPkg/Tools/GenCfgData.py
+++ b/SetupDataPkg/Tools/GenCfgData.py
@@ -2048,7 +2048,8 @@ class CGenCfgData:
             if idx > 0:
                 last_struct = struct_list[idx - 1]['node']['$STRUCT']
                 curr_struct = each['node']['$STRUCT']
-                if struct_list[idx - 1]['alias'] == each['alias'] and \
+                if 'struct' not in curr_struct and \
+                   struct_list[idx - 1]['alias'] == each['alias'] and \
                    curr_struct['length'] == last_struct['length'] and \
                    curr_struct['offset'] == last_struct['offset'] + last_struct['length']:
                     for idx2 in range(idx - 1, -1, -1):

--- a/SetupDataPkg/Tools/GenCfgData_test.py
+++ b/SetupDataPkg/Tools/GenCfgData_test.py
@@ -14,7 +14,7 @@ from GenCfgData import CGenCfgData
 from GenNCCfgData import CGenNCCfgData
 
 
-class UncoreCfgUnitTests(unittest.TestCase):
+class UefiCfgUnitTests(unittest.TestCase):
 
     # General test for loading yml file and making sure all config is there
     def test_yml_to_config(self):

--- a/SetupDataPkg/Tools/GenCfgData_test.py
+++ b/SetupDataPkg/Tools/GenCfgData_test.py
@@ -55,7 +55,7 @@ class UefiCfgUnitTests(unittest.TestCase):
             # we only want to check the values that are in YML, not metadata
             if item['type'] != 'Reserved':
                 # for multiple embedded structs of the same kind, multiple instances of the same cname will show up in^M
-               # the exec. We will need to find ours.^M
+                # the exec. We will need to find ours.^M
                 if not item['cname'] in exec:
                     found_in_exec = False
                     for each in exec:

--- a/SetupDataPkg/Tools/GenCfgData_test.py
+++ b/SetupDataPkg/Tools/GenCfgData_test.py
@@ -54,7 +54,20 @@ class UefiCfgUnitTests(unittest.TestCase):
             exec = cdata.locate_exec_from_item(cfg_item)
             # we only want to check the values that are in YML, not metadata
             if item['type'] != 'Reserved':
-                self.assertEqual(exec[item['cname']]['value'], item['value'])
+                # for multiple embedded structs of the same kind, multiple instances of the same cname will show up in^M
+               # the exec. We will need to find ours.^M
+                if not item['cname'] in exec:
+                    found_in_exec = False
+                    for each in exec:
+                        if item['cname'] in exec[each]:
+                            if exec[each][item['cname']]['value'] == item['value']:
+                                found_in_exec = True
+                                break
+                else:
+                    found_in_exec = True
+                    self.assertEqual(exec[item['cname']]['value'], item['value'])
+
+                self.assertEqual(found_in_exec, True)
                 self.assertEqual(item['value'], cfg_item['value'])
 
     # test to load yml, change config, generate a delta file, and load it again
@@ -234,7 +247,7 @@ class UefiCfgUnitTests(unittest.TestCase):
         self.assertEqual('0', item['value'])
 
         item = cdata.get_item_by_path('PLATFORM_CFG_DATA.PlatformName')
-        self.assertEqual("'PlatName'", item['value'])
+        self.assertEqual("'PLAT'", item['value'])
 
         # Test Full SVD
         settings = []
@@ -275,7 +288,7 @@ class UefiCfgUnitTests(unittest.TestCase):
         self.assertEqual('0', item['value'])
 
         item = cdata.get_item_by_path('PLATFORM_CFG_DATA.PlatformName')
-        self.assertEqual("'PlatName'", item['value'])
+        self.assertEqual("'PLAT'", item['value'])
 
     # Test to create/load varlist bins for YML only
     def test_yml_generate_load_bin(self):
@@ -335,7 +348,7 @@ class UefiCfgUnitTests(unittest.TestCase):
         self.assertEqual('0', item['value'])
 
         item = cdata.get_item_by_path('PLATFORM_CFG_DATA.PlatformName')
-        self.assertEqual("'PlatName'", item['value'])
+        self.assertEqual("'PLAT'", item['value'])
 
     # General test to load both yml and xml and confirm the config
     def test_merged_yml_xml_generate_load_svd(self):
@@ -651,7 +664,7 @@ class UefiCfgUnitTests(unittest.TestCase):
         os.remove(path)
 
         item = ydata.get_item_by_path('PLATFORM_CFG_DATA.PlatformName')
-        self.assertEqual("'PlatName'", item['value'])
+        self.assertEqual("'PLAT'", item['value'])
 
         item = ydata.get_item_by_path('GFX_CFG_DATA.PowerOnPort0')
         self.assertEqual('0', item['value'])

--- a/SetupDataPkg/Tools/samplecfg.yaml
+++ b/SetupDataPkg/Tools/samplecfg.yaml
@@ -33,7 +33,7 @@ configs:
     - PlatformName   :
         name         : Platform Name
         length       : 0x08
-        value        : 'CCv1'
+        value        : 'PLAT'
 
   - GFX_CFG_DATA :
     - IdTag          : 0x300

--- a/SetupDataPkg/Tools/samplecfg.yaml
+++ b/SetupDataPkg/Tools/samplecfg.yaml
@@ -16,13 +16,13 @@ template:
         length       : 0x02
         value        : $(2)
 
-  GPIO_TMPL: >
+  IO_TMPL: >
     - $STRUCT      :
-        name         : GPIO $(1) Half0
-        struct       : GPIO_DATA
+        name         : IO Port $(1)
+        struct       : IO_DATA
         length       : 0x02
     - Overdrive    :
-        name         : GPIO $(1) Overdrive
+        name         : IO $(1) Overdrive
         length       : 2
         value        : $(2)
 
@@ -35,13 +35,17 @@ configs:
         length       : 0x08
         value        : 'CCv1'
 
-  - GPIO_CFG_DATA    :
-    - IdTag          : 0x380
-    - Half0:
-      - !expand { GPIO_TMPL : [ 0 , 1] }
-    - Half1:
-      - !expand { GPIO_TMPL : [ 1 , 2] }
-
   - GFX_CFG_DATA :
     - IdTag          : 0x300
     - !expand { GFX_CONF_TMPL : [ 0, 1 ] }
+
+  - IO_CFG_DATA    :
+    - IdTag          : 0x380
+    - Flags:
+        name         : IO port flags
+        length       : 0x02
+        value        : 0xBEEF
+    - Port0:
+      - !expand { IO_TMPL : [ 0 , 1] }
+    - Port1:
+      - !expand { IO_TMPL : [ 1 , 2] }

--- a/SetupDataPkg/Tools/samplecfg.yaml
+++ b/SetupDataPkg/Tools/samplecfg.yaml
@@ -16,6 +16,16 @@ template:
         length       : 0x02
         value        : $(2)
 
+  GPIO_TMPL: >
+    - $STRUCT      :
+        name         : GPIO $(1) Half0
+        struct       : GPIO_DATA
+        length       : 0x02
+    - Overdrive    :
+        name         : GPIO $(1) Overdrive
+        length       : 2
+        value        : $(2)
+
 
 configs:
   - PLATFORM_CFG_DATA :
@@ -23,7 +33,14 @@ configs:
     - PlatformName   :
         name         : Platform Name
         length       : 0x08
-        value        : 'PlatName'
+        value        : 'CCv1'
+
+  - GPIO_CFG_DATA    :
+    - IdTag          : 0x380
+    - Half0:
+      - !expand { GPIO_TMPL : [ 0 , 1] }
+    - Half1:
+      - !expand { GPIO_TMPL : [ 1 , 2] }
 
   - GFX_CFG_DATA :
     - IdTag          : 0x300

--- a/SetupDataPkg/Tools/samplecfg_UI.yaml
+++ b/SetupDataPkg/Tools/samplecfg_UI.yaml
@@ -17,10 +17,17 @@ template:
         help         : >
                         GFX port power configuration
 
+  GPIO_TMPL: >
+    - Overdrive     :
+        type         : Combo
+        option       : 0x0:Disable, 0x1:Enable, 0x2:Overdrive
+        help         : >
+                      Enable/Disable ACPI feature. 1:ACPI Enabled, 0:ACPI Disabled
+
 
 configs:
   - $ACTION      :
-      page         : PLT::"Platform", GFX::"GFX Configuration"
+      page         : PLT::"Platform", GIO::"GPIO Configuration", GFX::"GFX Configuration"
 
   - $ACTION      :
       page         : PLT
@@ -30,6 +37,15 @@ configs:
         type         : EditText
         help         : >
                        Specify platform name here
+
+  - $ACTION      :
+      page         : GIO
+
+  - GPIO_CFG_DATA  :
+    - Half0:
+      - !expand { GPIO_TMPL : [ GPIO_0                 , 0x000500c5] }
+    - Half1:
+      - !expand { GPIO_TMPL : [ GPIO_1                 , 0x000508c5] }
 
   - $ACTION      :
       page         : GFX

--- a/SetupDataPkg/Tools/samplecfg_UI.yaml
+++ b/SetupDataPkg/Tools/samplecfg_UI.yaml
@@ -17,17 +17,17 @@ template:
         help         : >
                         GFX port power configuration
 
-  GPIO_TMPL: >
+  IO_TMPL: >
     - Overdrive     :
         type         : Combo
         option       : 0x0:Disable, 0x1:Enable, 0x2:Overdrive
         help         : >
-                      Enable/Disable ACPI feature. 1:ACPI Enabled, 0:ACPI Disabled
+                      Enable/Disable IO feature. 2:Overdrive, 1: Enabled, 0: Disabled
 
 
 configs:
   - $ACTION      :
-      page         : PLT::"Platform", GIO::"GPIO Configuration", GFX::"GFX Configuration"
+      page         : PLT::"Platform", IO::"IO Configuration", GFX::"GFX Configuration"
 
   - $ACTION      :
       page         : PLT
@@ -39,16 +39,20 @@ configs:
                        Specify platform name here
 
   - $ACTION      :
-      page         : GIO
-
-  - GPIO_CFG_DATA  :
-    - Half0:
-      - !expand { GPIO_TMPL : [ GPIO_0                 , 0x000500c5] }
-    - Half1:
-      - !expand { GPIO_TMPL : [ GPIO_1                 , 0x000508c5] }
-
-  - $ACTION      :
       page         : GFX
 
   - GFX_CFG_DATA  :
     - !expand { GFX_CONF_TMPL : [ 0, 1 ] }
+
+  - $ACTION      :
+      page         : IO
+
+  - IO_CFG_DATA  :
+    - Flags:
+        type         : EditNum
+        help         : >
+                       Specify IO flags here
+    - Port0:
+      - !expand { IO_TMPL : [ 0 , 1] }
+    - Port1:
+      - !expand { IO_TMPL : [ 1 , 2] }


### PR DESCRIPTION
The original code had heuristic method to merge contiguous fields in a struct into an array of field. (i.e. GPIO_0, GPIO_1 -> GPIO[2]). However, when it comes to an array of structures, the `struct_dict` will be constructed to prevent duplicate structure definitions, `struct_list` will then be inherited from such dictionary with the heuristic method applied to the corresponding 'count' field.

During `create_struct` routine, the struct alias will be evaluated. This name could support a `[N]` notation, denoting there are N structures here. However, the output field will then be written using the 'count' value. This method is also less undesirable when it comes to specifying individual structure default values.

Thus, defining 2 fields with the same struct name, will be nullified by the heuristic merging method, defining 2 fields with the same name and struct, will be nullified by the dictionary construction step.

The change is to only apply the heuristic merge method for non-struct nodes. The YAML example is also added.