### PR TITLE
Extended the size limit in the tag header to 18 bits

### DIFF
--- a/SetupDataPkg/Tools/GenCfgData.py
+++ b/SetupDataPkg/Tools/GenCfgData.py
@@ -519,8 +519,7 @@ class CFG_YAML():
                             # for now
                             cfg_hdr = OrderedDict()
                             cfg_hdr['length'] = '0x05'
-                            cfg_hdr['value'] = HEADER_TEMPLATE %\
-                                               (parent_name, 0 if key == "IdTag" else 1, value_str)
+                            cfg_hdr['value'] = HEADER_TEMPLATE % (parent_name, 0 if key == "IdTag" else 1, value_str)
                             curr['CfgHeader'] = cfg_hdr
 
                             cnd_val = OrderedDict()

--- a/SetupDataPkg/Tools/GenCfgData.py
+++ b/SetupDataPkg/Tools/GenCfgData.py
@@ -508,8 +508,8 @@ class CFG_YAML():
                             # Insert the headers corresponds to this ID tag from here, most contents are hardcoded
                             # for now
                             cfg_hdr = OrderedDict()
-                            cfg_hdr['length'] = '0x04'
-                            cfg_hdr['value'] = '{0x01:2b, (_LENGTH_%s_):10b, %d:4b, 0:4b, %s:12b}' %\
+                            cfg_hdr['length'] = '0x05'
+                            cfg_hdr['value'] = '{0x01:2b, (_LENGTH_%s_):18b, %d:4b, 0:4b, %s:12b}' %\
                                                (parent_name, 0 if key == "IdTag" else 1, value_str)
                             curr['CfgHeader'] = cfg_hdr
 
@@ -2023,7 +2023,8 @@ class CGenCfgData:
                 if 'CfgHeader' in cfgs:
                     # collect CFGDATA TAG IDs
                     cfg_hdr = self.get_item_by_index(cfgs['CfgHeader']['indx'])
-                    tag_val = array_str_to_value(cfg_hdr['value']) >> 20
+                    # This is to accomodate the header struct length field change
+                    tag_val = array_str_to_value(cfg_hdr['value']) >> 28
                     tag_dict[name] = tag_val
                     if level == 1:
                         tag_curr[0] = tag_val

--- a/SetupDataPkg/Tools/GenCfgData.py
+++ b/SetupDataPkg/Tools/GenCfgData.py
@@ -1454,7 +1454,6 @@ class CGenCfgData:
 
         # update the exec itself
         exec = self.locate_exec_from_tag(tag_id)
-        # print (f"bin_data: {bin_data} exec: {exec} tag_id: {tag_id}")
         self.set_field_value(exec, bin_data)
         _update_tree(exec, bin_data)
 
@@ -1523,7 +1522,6 @@ class CGenCfgData:
                 bit_len = struct_info['length']
 
             value_bytes = self.parse_value(value_str, bit_len)
-            # print (top)
             self.set_field_value(top, value_bytes, True)
 
             if path == 'PLATFORMID_CFG_DATA.PlatformId':

--- a/SetupDataPkg/Tools/GenCfgData.py
+++ b/SetupDataPkg/Tools/GenCfgData.py
@@ -104,9 +104,9 @@ def array_str_to_value(val_str):
 
 def extract_tag_val(val_str):
     if HEADER_TEMPLATE != '{0x01:2b, (_LENGTH_%s_):18b, %d:4b, 0:4b, %s:12b}':
-        raise Exception ("Did you just update the header template? The calculation below might need to change!")
+        raise Exception("Did you just update the header template? The calculation below might need to change!")
 
-    raw_val = array_str_to_value (val_str)
+    raw_val = array_str_to_value(val_str)
     tag_val = (raw_val >> 28) & 0xFFF
     return tag_val
 
@@ -1455,6 +1455,7 @@ class CGenCfgData:
 
         # update the exec itself
         exec = self.locate_exec_from_tag(tag_id)
+        # print (f"bin_data: {bin_data} exec: {exec} tag_id: {tag_id}")
         self.set_field_value(exec, bin_data)
         _update_tree(exec, bin_data)
 
@@ -1523,6 +1524,7 @@ class CGenCfgData:
                 bit_len = struct_info['length']
 
             value_bytes = self.parse_value(value_str, bit_len)
+            # print (top)
             self.set_field_value(top, value_bytes, True)
 
             if path == 'PLATFORMID_CFG_DATA.PlatformId':
@@ -1600,7 +1602,7 @@ class CGenCfgData:
             offset += int(exec['CfgHeader']['length'], 0)
             offset += int(exec['CondValue']['length'], 0)
             cfg_hdr = self.get_item_by_index(exec["CfgHeader"]["indx"])
-            tag_val = extract_tag_val (cfg_hdr['value'])
+            tag_val = extract_tag_val(cfg_hdr['value'])
             name = "Device.ConfigData.TagID_%08x" % tag_val
             var = UEFIVariable(name, uuid.UUID(SETUP_CONFIG_POLICY_VAR_GUID), bytes[offset:], attributes=3)
             buf = create_vlist_buffer(var)
@@ -1700,7 +1702,7 @@ class CGenCfgData:
                 exec[0] = cfgs
                 if CGenCfgData.STRUCT in cfgs:
                     cfg_hdr = self.get_item_by_index(cfgs['CfgHeader']['indx'])
-                    tag_val = extract_tag_val (cfg_hdr['value'])
+                    tag_val = extract_tag_val(cfg_hdr['value'])
                     if tag_val == tag:
                         exec[1] = exec[0]
 
@@ -2033,7 +2035,7 @@ class CGenCfgData:
                 if 'CfgHeader' in cfgs:
                     # collect CFGDATA TAG IDs
                     cfg_hdr = self.get_item_by_index(cfgs['CfgHeader']['indx'])
-                    tag_val = extract_tag_val (cfg_hdr['value'])
+                    tag_val = extract_tag_val(cfg_hdr['value'])
                     tag_dict[name] = tag_val
                     if level == 1:
                         tag_curr[0] = tag_val


### PR DESCRIPTION
The practical use case start to exceed the size limit defined by the 10bit length in the tag structure header.

This change extends the size limit to 18bit wide, which will allow up to 256K. The change will not impact the output binary/svd data as it is consumed internally by the GenCfgData.py script.