### PR TITLE
Update MU dependencies to be based on MU 202208

### DIFF
--- a/basecore_ext_dep.yaml
+++ b/basecore_ext_dep.yaml
@@ -9,6 +9,6 @@
   "name": "MU_BASECORE",
   "var_name": "BASECORE_PATH",
   "source": "https://github.com/microsoft/mu_basecore.git",
-  "version": "c4d0d1130454b3e5051bb601c707234e3a91713a", # release/202202
+  "version": "0e24f15f6c79508f6daa84e18d4c0d7bb053a9bd", # release/202208
   "flags": ["set_build_var"]
 }

--- a/mu_plus_ext_dep.yaml
+++ b/mu_plus_ext_dep.yaml
@@ -9,6 +9,6 @@
   "name": "MU_PLUS",
   "var_name": "MU_PLUS_PATH",
   "source": "https://github.com/microsoft/mu_plus.git",
-  "version": "7f74fbf7698b9b5698a520aee1003bb409bfc613", # release/202202
+  "version": "a298f6a77d74cf1e293f9e985eaf8ab7b59789c7", # release/202208
   "flags": ["set_build_var"]
 }

--- a/mu_tiano_ext_dep.yaml
+++ b/mu_tiano_ext_dep.yaml
@@ -9,6 +9,6 @@
   "name": "MU_TIANO_PLUS",
   "var_name": "MU_TIANO_PATH",
   "source": "https://github.com/microsoft/mu_tiano_plus.git",
-  "version": "81f1216adc1d7f8596fd5b4bbed439b1dfb992df", # release/202202
+  "version": "0ea3ed5ec5d655a4e533113f21387678932ff0fc", # release/202208
   "flags": ["set_build_var"]
 }

--- a/pip-requirements.txt
+++ b/pip-requirements.txt
@@ -12,8 +12,9 @@
 # https://www.python.org/dev/peps/pep-0440/#version-specifiers
 ##
 
-edk2-pytool-library~=0.11.2 # MU_CHANGE - update to 0.11.2 or later
-edk2-pytool-extensions~=0.17.1 # MU_CHANGE - update to 0.17.1 or later
-edk2-basetools==0.1.13 # MU_CHANGE - update to 0.1.13 or later
-antlr4-python3-runtime==4.7.1
+edk2-pytool-library~=0.11.6 # MU_CHANGE - update to 0.11.6 or later
+edk2-pytool-extensions~=0.19.1 # MU_CHANGE - update to 0.19.1 or later
+edk2-basetools==0.1.29 # MU_CHANGE - update to 0.1.29 or later
+antlr4-python3-runtime==4.11.1
 xmlschema==2.0.1 # MU_CHANGE - update to 2.0.1 or later
+regex==2022.8.17


### PR DESCRIPTION
Updated BASECORE, MU_PLUS and MU_TIANO_PLUS repos to be based on MU 202208 release branches.