### PR TITLE
SetupDataPkg: Fix imbalanced DEBUG macros

### DIFF
--- a/SetupDataPkg/ConfApp/SystemInfo.c
+++ b/SetupDataPkg/ConfApp/SystemInfo.c
@@ -157,13 +157,13 @@ PrintVersion (
     if (FmpImageInfoBuf->ImageIdName != NULL) {
       Status = Print (L"\t%s:\t", FmpImageInfoBuf->ImageIdName);
     } else {
-      DEBUG ((DEBUG_ERROR, "%a - FMP ImageIdName is null\n"));
+      DEBUG ((DEBUG_ERROR, "%a - FMP ImageIdName is null\n", __FUNCTION__));
     }
 
     if (FmpImageInfoBuf->VersionName != NULL) {
       Status = Print (L"%s\n", FmpImageInfoBuf->VersionName);
     } else {
-      DEBUG ((DEBUG_ERROR, "%a - FMP VersionName is null\n"));
+      DEBUG ((DEBUG_ERROR, "%a - FMP VersionName is null\n", __FUNCTION__));
     }
 
 FmpCleanUp:

--- a/SetupDataPkg/ConfProfileMgrDxe/ConfProfileMgrDxe.c
+++ b/SetupDataPkg/ConfProfileMgrDxe/ConfProfileMgrDxe.c
@@ -218,7 +218,7 @@ ConfProfileMgrDxeEntry (
     DEBUG ((DEBUG_ERROR, "%a RetrieveActiveProfileGuid failed (%r)! Attempting to use cached profile\n", __FUNCTION__, Status));
 
     if (!FoundCachedProfile) {
-      DEBUG ((DEBUG_ERROR, "%a Failed to retrieve cached profile, using generic profile\n", __FUNCTION__, Status));
+      DEBUG ((DEBUG_ERROR, "%a Failed to retrieve cached profile, using generic profile\n", __FUNCTION__));
     }
 
     CopyMem (&ActiveProfileGuid, &CachedProfile, Size);


### PR DESCRIPTION
Fixes the following issues reported by the DebugMacroCheck plugin:

```
  Checking DEBUG Macros

  File: ConfApp/SystemInfo.c
    Message         = "%a - FMP ImageIdName is null\n"
    Arguments       = ""
    Specifier Count = 1
    Argument Count  = 0
  File: ConfApp/SystemInfo.c
    Message         = "%a - FMP VersionName is null\n"
    Arguments       = ""
    Specifier Count = 1
    Argument Count  = 0
  File: ConfProfileMgrDxe/ConfProfileMgrDxe.c
    Message         = "%a Failed to retrieve cached profile, using generic profile\n"
    Arguments       = ", __FUNCTION__, Status"
    Specifier Count = 1
    Argument Count  = 2

  3 debug macro errors in 34 files
  Plugin Failed: Debug Macro Check Plugin returned 3
```

Signed-off-by: Michael Kubacki <michael.kubacki@microsoft.com>