### PR TITLE
Save Delta CSV When User Requests

### DIFF
--- a/SetupDataPkg/Tools/GenNCCfgData.py
+++ b/SetupDataPkg/Tools/GenNCCfgData.py
@@ -279,9 +279,11 @@ class CGenNCCfgData:
         self.sync_shim_and_schema()
         return 0
 
-    def generate_delta_file_from_bin(self, delta_file, old_data, new_data, full=False):
+    def generate_delta_file_from_bin(self, delta_file, old_data, new_data, full, subknobs=False):
         self.load_default_from_bin(new_data, True)
-        write_csv(self.schema, delta_file, subknobs=full)
+        # by default, create smaller csv files with only the full knobs. If more detail is required
+        # this default can be changed to include the subknobs
+        write_csv(self.schema, delta_file, full, subknobs=subknobs)
         return 0
 
     def generate_csv_file(self, delta_file, bin_file, bin_file2, full=False):
@@ -297,7 +299,7 @@ class CGenNCCfgData:
             new_data = bytearray(fd.read())
             fd.close()
 
-        return self.generate_delta_file_from_bin(delta_file, old_data, new_data, full)
+        return self.generate_delta_file_from_bin(delta_file, old_data, new_data, full, True)
 
     def load_xml(self, cfg_file):
         self.initialize(cfg_file)

--- a/SetupDataPkg/Tools/GenNCCfgData.py
+++ b/SetupDataPkg/Tools/GenNCCfgData.py
@@ -299,7 +299,7 @@ class CGenNCCfgData:
             new_data = bytearray(fd.read())
             fd.close()
 
-        return self.generate_delta_file_from_bin(delta_file, old_data, new_data, full, True)
+        return self.generate_delta_file_from_bin(delta_file, old_data, new_data, full, False)
 
     def load_xml(self, cfg_file):
         self.initialize(cfg_file)

--- a/SetupDataPkg/Tools/VariableList.py
+++ b/SetupDataPkg/Tools/VariableList.py
@@ -1182,13 +1182,13 @@ def write_csv(schema, csv_path, full, subknobs=True):
     with open(csv_path, 'w', newline='') as csv_file:
         writer = csv.writer(csv_file)
 
-        # delta_vlist is a tuple of name_list, var_list
-        delta_vlist = get_delta_vlist(schema)
+        # get_delta_vlist is a tuple of name_list, var_list
+        name_list = get_delta_vlist(schema)[0]
 
         if subknobs:
             writer.writerow(['Knob', 'Value', 'Help'])
             for subknob in schema.subknobs:
-                if full or subknob.name in delta_vlist[0]:
+                if full or subknob.name in name_list:
                     writer.writerow([
                         subknob.name,
                         subknob.format.object_to_string(subknob.value),
@@ -1196,7 +1196,7 @@ def write_csv(schema, csv_path, full, subknobs=True):
         else:
             writer.writerow(['Knob', 'Value', 'Help'])
             for knob in schema.knobs:
-                if full or knob.name in delta_vlist[0]:
+                if full or knob.name in name_list:
                     writer.writerow([
                         knob.name,
                         knob.format.object_to_string(knob.value),

--- a/SetupDataPkg/Tools/VariableList.py
+++ b/SetupDataPkg/Tools/VariableList.py
@@ -1178,24 +1178,29 @@ def read_csv(schema, csv_path):
             knob.value = knob.format.string_to_object(knob_value_string)
 
 
-def write_csv(schema, csv_path, subknobs=True):
+def write_csv(schema, csv_path, full, subknobs=True):
     with open(csv_path, 'w', newline='') as csv_file:
         writer = csv.writer(csv_file)
+
+        # delta_vlist is a tuple of name_list, var_list
+        delta_vlist = get_delta_vlist(schema)
 
         if subknobs:
             writer.writerow(['Knob', 'Value', 'Help'])
             for subknob in schema.subknobs:
-                writer.writerow([
-                    subknob.name,
-                    subknob.format.object_to_string(subknob.value),
-                    subknob.help])
+                if full or subknob.name in delta_vlist[0]:
+                    writer.writerow([
+                        subknob.name,
+                        subknob.format.object_to_string(subknob.value),
+                        subknob.help])
         else:
             writer.writerow(['Knob', 'Value', 'Help'])
             for knob in schema.knobs:
-                writer.writerow([
-                    knob.name,
-                    knob.format.object_to_string(knob.value),
-                    knob.help])
+                if full or knob.name in delta_vlist[0]:
+                    writer.writerow([
+                        knob.name,
+                        knob.format.object_to_string(knob.value),
+                        knob.help])
 
 
 def write_vlist(schema, vlist_path):

--- a/SetupDataPkg/Tools/VariableList.py
+++ b/SetupDataPkg/Tools/VariableList.py
@@ -1272,8 +1272,8 @@ def main():
             for knob in schema.knobs:
                 knob.value = knob.default
 
-            # Write the vlist
-            write_csv(schema, csv_path)
+            # Write the full vlist with complete knobs
+            write_csv(schema, csv_path, True, False)
         elif len(sys.argv) == 5:
             schema_path = sys.argv[2]
             vlist_path = sys.argv[3]
@@ -1285,8 +1285,8 @@ def main():
             # Read values from the vlist
             read_vlist(schema, vlist_path)
 
-            # Write the CSV
-            write_csv(schema, csv_path)
+            # Write the full vlist CSV with complete knobs
+            write_csv(schema, csv_path, True, False)
         else:
             usage()
             sys.stderr.write('Invalid number of arguments.\n')


### PR DESCRIPTION
There is a current bug where saving a delta CSV saves the full config data to the CSV. This PR also makes a choice to not save all subknobs to the CSV in order to save space.