### PR TITLE
Fixed issue where subknobs are updated

### DIFF
--- a/SetupDataPkg/Tools/VariableList.py
+++ b/SetupDataPkg/Tools/VariableList.py
@@ -851,6 +851,11 @@ class Knob:
             if child_object is None:
                 child_object = self.default
 
+            # The full object is the entire object represented by the knob
+            # the child object will be updated to point to sub-objects within the full object
+            # until the final value can be updated
+            full_object = child_object
+
             first_element = path_elements[0]
             if first_element != self.name:
                 raise Exception(
@@ -870,13 +875,17 @@ class Knob:
                 else:
                     child_object = child_object[name][index]
 
+            # The last iteration is in reference to a value, not an object, so we
+            # will use the last child_object pointer to update the value
             (name, index) = self._decode_subpath(final_element)
             if index is None:
                 child_object[name] = value
             else:
                 child_object[name][index] = value
 
-            self.value = child_object
+            # Update the knob to the value of the full_object, which has been modified by virtue of
+            # updating the child object (which was a pointer to an internal structure of the full object)
+            self.value = full_object
 
     def _decode_subpath(self, subpath_segment):
         match = re.match(
@@ -913,9 +922,6 @@ class SubKnob:
 
     @value.setter
     def value(self, value):
-        if self.knob.value is None:
-            self.knob.value = self.knob.default
-
         self.knob._set_child_value(self.name, value)
         pass
 

--- a/SetupDataPkg/Tools/VariableList_test.py
+++ b/SetupDataPkg/Tools/VariableList_test.py
@@ -46,6 +46,12 @@ class SchemaParseUnitTests(unittest.TestCase):
         <Value name="v_1" value="1" />
         <Value name="v_n1" value="-1" />
     </Enum>
+
+    <Enum name="OPTION_MODE" help="Modes of the option">
+      <Value name="FIRST" value="0" help="First mode" />
+      <Value name="SECOND" value="1" help="Second mode" />
+      <Value name="THIRD" value="2" help="Third mode" />
+    </Enum>
   </Enums>
 
   <Structs>
@@ -69,6 +75,19 @@ class SchemaParseUnitTests(unittest.TestCase):
 
     <Struct name="s_array_structs_t">
         <Member name="m_s_simple_t_c5" type="s_simple_t" count="5" />
+    </Struct>
+
+
+    <Struct name="simple_t" help="Simple struct">
+      <Member name="value" count="2" type="uint32_t" />
+    </Struct>
+    <Struct name="child_t" help="Embedded struct">
+      <Member name="data" type="uint8_t" count="5" help="Bytes" />
+      <Member name="mode" type="OPTION_MODE" />
+    </Struct>
+    <Struct name="sample_t" help="Sample struct">
+      <Member name="counter" type="uint32_t" help="Number value" />
+      <Member name="children" type="child_t" count="2" help="Child data" />
     </Struct>
 
   </Structs>
@@ -170,6 +189,9 @@ class SchemaParseUnitTests(unittest.TestCase):
     <Knob type="s_array_t" name="k_s_array_t_d5" default="{{5}}"/>
 
     <Knob type="s_array_structs_t" name="k_s_array_structs_t" />
+
+    
+    <Knob name="COMPLEX_KNOB2" type="sample_t" default="{2,{{{1,2,3, 4,5 },FIRST },{{6,7,8, 9,10 },SECOND }}}" help="Complex type" />
 
   </Knobs>
 
@@ -447,6 +469,22 @@ class SchemaParseUnitTests(unittest.TestCase):
 </Structs>""")
         with pytest.raises(InvalidRangeError):
             Schema(dom)
+
+    def test_sample_config(self):
+        schema = Schema.parse(self.schemaTemplate)
+
+        # Get the a subknob and modify a single element
+        subknob = schema.get_knob("COMPLEX_KNOB2.counter")
+        subknob.value = 4
+        self.assertEqual(subknob.value, 4)
+
+    def test_sample_config2(self):
+        schema = Schema.parse(self.schemaTemplate)
+
+        # Get the a subknob and modify a single element
+        subknob = schema.get_knob("COMPLEX_KNOB2.children[0].data[0]")
+        subknob.value = 4
+        self.assertEqual(subknob.value, 4)
 
     def test_more_restrictive_knob_limit(self):
         # If a knob has more restrictive limits than its type


### PR DESCRIPTION
During subknob updates the value could be incorrect resulting in a validation error and exception when updating the knob.