### PR TITLE
Make enums and structs optional in the xml schema

### DIFF
--- a/SetupDataPkg/Tools/configschema.xsd
+++ b/SetupDataPkg/Tools/configschema.xsd
@@ -3,7 +3,7 @@
   <xs:element name="ConfigSchema">
     <xs:complexType>
       <xs:sequence>
-        <xs:element name="Enums" maxOccurs="1">
+        <xs:element name="Enums" minOccurs="0" maxOccurs="1">
           <xs:complexType>
             <xs:sequence>
               <xs:element name="Enum" maxOccurs="unbounded">
@@ -26,7 +26,7 @@
             </xs:sequence>
           </xs:complexType>
         </xs:element>
-        <xs:element name="Structs" maxOccurs="1">
+        <xs:element name="Structs" minOccurs="0" maxOccurs="1">
           <xs:complexType>
             <xs:sequence>
               <xs:element name="Struct" maxOccurs="unbounded">


### PR DESCRIPTION
The schema defined in SetupDataPkg/Tools/configschema.xsd currently
enforces that a configuration definition must have enums and structs
defined. However, there are valid use-cases where a user may just want
to define knobs using standard data types. To support such use-cases
update the schema to make structs/enums optional.
