### PR TITLE
Added binary CSV column

### DIFF
--- a/SetupDataPkg/Tools/VariableList.py
+++ b/SetupDataPkg/Tools/VariableList.py
@@ -1192,20 +1192,26 @@ def write_csv(schema, csv_path, full, subknobs=True):
         name_list = get_delta_vlist(schema)[0]
 
         if subknobs:
-            writer.writerow(['Knob', 'Value', 'Help'])
+            writer.writerow(['Knob', 'Value', 'Binary', 'Comment'])
             for subknob in schema.subknobs:
                 if full or subknob.name in name_list:
+                    binary = subknob.format.object_to_binary(subknob.value)
+                    string_binary = " ".join(map("%2.2x".__mod__, binary))
                     writer.writerow([
                         subknob.name,
                         subknob.format.object_to_string(subknob.value),
+                        string_binary,
                         subknob.help])
         else:
-            writer.writerow(['Knob', 'Value', 'Help'])
+            writer.writerow(['Knob', 'Value', 'Binary', 'Comment'])
             for knob in schema.knobs:
                 if full or knob.name in name_list:
+                    binary = knob.format.object_to_binary(knob.value)
+                    string_binary = " ".join(map("%2.2x".__mod__, binary))
                     writer.writerow([
                         knob.name,
                         knob.format.object_to_string(knob.value),
+                        string_binary,
                         knob.help])
 
 


### PR DESCRIPTION
## Description

Added a binary column to the CSV file format to show the binary representation of values.

This is added to aid users who need to manually update knobs by directly editing UEFI variables. The binary value shows the correct representation for a given value.

The value is written by the tools, but is ignored when read, similar to the Comment/Help column. The Help column was renamed to Comment to make clear it can be used for other notes in saved CSVs. 

For each item, place an "x" in between `[` and `]` if true. Example: `[x]`.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Manually verified

## Integration Instructions
