### PR TITLE
Allow arbitrary SVD values to be set through ConfApp

### DIFF
--- a/SetupDataPkg/ConfApp/SetupConf.c
+++ b/SetupDataPkg/ConfApp/SetupConf.c
@@ -541,7 +541,7 @@ ApplySettings (
       }
     } else {
       // this is not a DFCI variable, just write the variable
-      Status = WriteSVDSetting (ValueSize, SetValue);
+      Status = WriteSVDSetting (SetValue, ValueSize);
     }
 
     DEBUG ((DEBUG_INFO, "%a - Set %a = %a. Result = %r\n", __FUNCTION__, Id, Value, Status));

--- a/SetupDataPkg/ConfApp/SetupConf.c
+++ b/SetupDataPkg/ConfApp/SetupConf.c
@@ -169,6 +169,122 @@ PrintOptions (
 }
 
 /**
+  Set arbitrary SVD values to variable storage
+
+  @param Value     a pointer to the variable list
+  @param ValueSize Size of the data for this setting.
+
+  @retval EFI_SUCCESS If setting could be set.  Check flags for other info (reset required, etc)
+  @retval Error       Setting not set.
+**/
+STATIC
+EFI_STATUS
+WriteSVDSetting (
+  IN        UINTN  ValueSize,
+  IN  CONST UINT8  *Value
+  )
+{
+  EFI_STATUS           Status          = EFI_SUCCESS;
+  CHAR16               *AlignedVarName = NULL;
+  CHAR16               *UnalignedVarName;
+  EFI_GUID             *Guid;
+  UINT32               Attributes;
+  CHAR8                *Data;
+  UINT32               CRC32;
+  UINT32               LenToCRC32;
+  UINT32               CalcCRC32 = 0;
+  CONFIG_VAR_LIST_HDR  *VarList;
+  UINT32               ListIndex = 0;
+
+  if ((Value == NULL) || (ValueSize == 0)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  while (ListIndex < ValueSize) {
+    // index into variable list
+    VarList = (CONFIG_VAR_LIST_HDR *)(Value + ListIndex);
+
+    if (ListIndex + sizeof (*VarList) + VarList->NameSize + VarList->DataSize + sizeof (*Guid) +
+        sizeof (Attributes) + sizeof (CRC32) > ValueSize)
+    {
+      // the NameSize and DataSize have bad values and are pushing us past the end of the binary
+      DEBUG ((DEBUG_ERROR, "SVD settings had bad NameSize or DataSize, unable to process all settings\n"));
+      break;
+    }
+
+    /*
+     * Var List is in DmpStore format:
+     *
+     *  struct {
+     *    RUNTIME_VAR_LIST_HDR VarList;
+     *    CHAR16 Name[VarList->NameSize/2];
+     *    EFI_GUID Guid;
+     *    UINT32 Attributes;
+     *    CHAR8 Data[VarList->DataSize];
+     *    UINT32 CRC32; // CRC32 of all bytes from VarList to end of Data
+     *  }
+     */
+    UnalignedVarName = (CHAR16 *)(VarList + 1);
+    Guid             = (EFI_GUID *)((CHAR8 *)UnalignedVarName + VarList->NameSize);
+    Attributes       = *(UINT32 *)(Guid + 1);
+    Data             = (CHAR8 *)Guid + sizeof (*Guid) + sizeof (Attributes);
+    CRC32            = *(UINT32 *)(Data + VarList->DataSize);
+    LenToCRC32       = sizeof (*VarList) + VarList->NameSize + VarList->DataSize + sizeof (*Guid) + sizeof (Attributes);
+
+    // on next iteration, skip past this variable
+    ListIndex += LenToCRC32 + sizeof (CRC32);
+
+    // validate CRC32
+    CalcCRC32 = CalculateCrc32 (VarList, LenToCRC32);
+
+    if (CalcCRC32 != CRC32) {
+      // CRC didn't match, drop this variable, continue to the next
+      DEBUG ((DEBUG_ERROR, "SVD setting failed CRC check, skipping applying setting: %a Status: %r \
+      Received CRC32: %u Calculated CRC32: %u\n", UnalignedVarName, Status, CRC32, CalcCRC32));
+      continue;
+    }
+
+    AlignedVarName = AllocatePool (VarList->NameSize);
+    if (AlignedVarName == NULL) {
+      Status = EFI_OUT_OF_RESOURCES;
+      return Status;
+    }
+
+    // Copy non-16 bit aligned UnalignedVarName to AlignedVarName, not using StrCpyS functions as they assert on non-16 bit alignment
+    CopyMem (AlignedVarName, UnalignedVarName, VarList->NameSize);
+
+    // first delete the variable in case of size or attributes change, not validated here as this is only allowed
+    // in manufacturing mode. Don't retrieve the status, if we fail to delete, try to write it anyway. If we fail
+    // there, just log it and move on
+    gRT->SetVariable (
+           AlignedVarName,
+           Guid,
+           0,
+           0,
+           NULL
+           );
+
+    // write variable directly to var storage
+    Status = gRT->SetVariable (
+                    AlignedVarName,
+                    Guid,
+                    Attributes,
+                    VarList->DataSize,
+                    Data
+                    );
+
+    if (EFI_ERROR (Status)) {
+      // failed to set variable, continue to try with other variables
+      DEBUG ((DEBUG_ERROR, "Failed to set SVD Setting %s, continuing to try next variables\n", AlignedVarName));
+    }
+
+    FreePool (AlignedVarName);
+  }
+
+  return Status;
+}
+
+/**
   Apply all settings from XML to their associated setting providers.
 
   @param[in] Buffer         Complete buffer of config settings in the format of XML.
@@ -357,13 +473,6 @@ ApplySettings (
       goto EXIT;
     }
 
-    // only care about our target
-    ZeroMem (&VarListEntry, sizeof (VarListEntry));
-    Status = QuerySingleActiveConfigAsciiVarList (Id, &VarListEntry);
-    if (EFI_ERROR (Status)) {
-      continue;
-    }
-
     // Now we have an Id and Value
     b64Size   = AsciiStrnLenS (Value, MAX_ALLOWABLE_DFCI_APPLY_VAR_SIZE);
     ValueSize = 0;
@@ -387,44 +496,54 @@ ApplySettings (
     DEBUG ((DEBUG_INFO, "Setting BINARY data\n"));
     DUMP_HEX (DEBUG_VERBOSE, 0, SetValue, ValueSize, "");
 
-    if (mSettingAccess == NULL) {
-      // Should not be here
-      Status = EFI_NOT_STARTED;
-      goto EXIT;
+    if ((0 == AsciiStrnCmp (Id, DFCI_OEM_SETTING_ID__CONF, AsciiStrLen (DFCI_OEM_SETTING_ID__CONF))) ||
+        (0 == AsciiStrnCmp (Id, SINGLE_SETTING_PROVIDER_START, AsciiStrLen (SINGLE_SETTING_PROVIDER_START))))
+    {
+      // only care about our target
+      ZeroMem (&VarListEntry, sizeof (VarListEntry));
+      Status = QuerySingleActiveConfigAsciiVarList (Id, &VarListEntry);
+      if (EFI_ERROR (Status)) {
+        FreePool (ByteArray);
+        continue;
+      }
+
+      // Now set the settings via DFCI
+      Status = mSettingAccess->Set (
+                                 mSettingAccess,
+                                 Id,
+                                 &mAuthToken,
+                                 DFCI_SETTING_TYPE_BINARY,
+                                 ValueSize,
+                                 SetValue,
+                                 &Flags
+                                 );
+
+      // Record Status result
+      ZeroMem (StatusString, sizeof (StatusString));
+      ZeroMem (FlagString, sizeof (FlagString));
+      StatusString[0] = '0';
+      StatusString[1] = 'x';
+      FlagString[0]   = '0';
+      FlagString[1]   = 'x';
+
+      AsciiValueToStringS (&(StatusString[2]), sizeof (StatusString)-2, RADIX_HEX, (INT64)Status, 18);
+      AsciiValueToStringS (&(FlagString[2]), sizeof (FlagString)-2, RADIX_HEX, (INT64)Flags, 18);
+      Status = SetOutputSettingsStatus (ResultSettingsNode, Id, &(StatusString[0]), &(FlagString[0]));
+      if (EFI_ERROR (Status)) {
+        DEBUG ((DEBUG_ERROR, "Failed to SetOutputSettingStatus.  %r\n", Status));
+        Status = EFI_DEVICE_ERROR;
+        goto EXIT;
+      }
+
+      if (Flags & DFCI_SETTING_FLAGS_OUT_REBOOT_REQUIRED) {
+        ResetRequired = TRUE;
+      }
+    } else {
+      // this is not a DFCI variable, just write the variable
+      Status = WriteSVDSetting (ValueSize, SetValue);
     }
 
-    // Now set the settings
-    Status = mSettingAccess->Set (
-                               mSettingAccess,
-                               Id,
-                               &mAuthToken,
-                               DFCI_SETTING_TYPE_BINARY,
-                               ValueSize,
-                               SetValue,
-                               &Flags
-                               );
     DEBUG ((DEBUG_INFO, "%a - Set %a = %a. Result = %r\n", __FUNCTION__, Id, Value, Status));
-
-    // Record Status result
-    ZeroMem (StatusString, sizeof (StatusString));
-    ZeroMem (FlagString, sizeof (FlagString));
-    StatusString[0] = '0';
-    StatusString[1] = 'x';
-    FlagString[0]   = '0';
-    FlagString[1]   = 'x';
-
-    AsciiValueToStringS (&(StatusString[2]), sizeof (StatusString)-2, RADIX_HEX, (INT64)Status, 18);
-    AsciiValueToStringS (&(FlagString[2]), sizeof (FlagString)-2, RADIX_HEX, (INT64)Flags, 18);
-    Status = SetOutputSettingsStatus (ResultSettingsNode, Id, &(StatusString[0]), &(FlagString[0]));
-    if (EFI_ERROR (Status)) {
-      DEBUG ((DEBUG_ERROR, "Failed to SetOutputSettingStatus.  %r\n", Status));
-      Status = EFI_DEVICE_ERROR;
-      goto EXIT;
-    }
-
-    if (Flags & DFCI_SETTING_FLAGS_OUT_REBOOT_REQUIRED) {
-      ResetRequired = TRUE;
-    }
 
     // all done.
   } // end for loop

--- a/SetupDataPkg/ConfApp/SetupConf.c
+++ b/SetupDataPkg/ConfApp/SetupConf.c
@@ -180,8 +180,8 @@ PrintOptions (
 STATIC
 EFI_STATUS
 WriteSVDSetting (
-  IN        UINTN  ValueSize,
-  IN  CONST UINT8  *Value
+  IN  CONST UINT8  *Value,
+  IN        UINTN  ValueSize
   )
 {
   EFI_STATUS           Status          = EFI_SUCCESS;
@@ -209,6 +209,7 @@ WriteSVDSetting (
     {
       // the NameSize and DataSize have bad values and are pushing us past the end of the binary
       DEBUG ((DEBUG_ERROR, "SVD settings had bad NameSize or DataSize, unable to process all settings\n"));
+      Status = EFI_COMPROMISED_DATA;
       break;
     }
 
@@ -216,7 +217,7 @@ WriteSVDSetting (
      * Var List is in DmpStore format:
      *
      *  struct {
-     *    RUNTIME_VAR_LIST_HDR VarList;
+     *    CONFIG_VAR_LIST_HDR VarList;
      *    CHAR16 Name[VarList->NameSize/2];
      *    EFI_GUID Guid;
      *    UINT32 Attributes;

--- a/SetupDataPkg/ConfApp/UnitTest/ConfAppSetupConfUnitTest.c
+++ b/SetupDataPkg/ConfApp/UnitTest/ConfAppSetupConfUnitTest.c
@@ -808,7 +808,6 @@ ConfAppSetupConfSelectSerialWithArbitrarySVD (
   UINTN                     Index;
   CHAR8                     *KnowGoodXml;
   BASE_LIBRARY_JUMP_BUFFER  JumpBuf;
-  CONTEXT_DATA              *Ctx;
 
   UT_ASSERT_NOT_NULL (Context);
   Ctx = (CONTEXT_DATA *)Context;

--- a/SetupDataPkg/ConfApp/UnitTest/ConfAppSetupConfUnitTest.c
+++ b/SetupDataPkg/ConfApp/UnitTest/ConfAppSetupConfUnitTest.c
@@ -809,9 +809,6 @@ ConfAppSetupConfSelectSerialWithArbitrarySVD (
   CHAR8                     *KnowGoodXml;
   BASE_LIBRARY_JUMP_BUFFER  JumpBuf;
 
-  UT_ASSERT_NOT_NULL (Context);
-  Ctx = (CONTEXT_DATA *)Context;
-
   will_return (MockClearScreen, EFI_SUCCESS);
   will_return_always (MockSetAttribute, EFI_SUCCESS);
 

--- a/SetupDataPkg/ConfApp/UnitTest/ConfAppSetupConfUnitTest.c
+++ b/SetupDataPkg/ConfApp/UnitTest/ConfAppSetupConfUnitTest.c
@@ -783,6 +783,111 @@ ConfAppSetupConfSelectSerial (
 }
 
 /**
+  Unit test for SetupConf page when selecting configure from serial and passing in arbitrary SVD variables.
+
+  @param[in]  Context    [Optional] An optional parameter that enables:
+                         1) test-case reuse with varied parameters and
+                         2) test-case re-entry for Target tests that need a
+                         reboot.  This parameter is a VOID* and it is the
+                         responsibility of the test author to ensure that the
+                         contents are well understood by all test cases that may
+                         consume it.
+
+  @retval  UNIT_TEST_PASSED             The Unit test has completed and the test
+                                        case was successful.
+  @retval  UNIT_TEST_ERROR_TEST_FAILED  A test case assertion has failed.
+**/
+UNIT_TEST_STATUS
+EFIAPI
+ConfAppSetupConfSelectSerialWithArbitrarySVD (
+  IN UNIT_TEST_CONTEXT  Context
+  )
+{
+  EFI_STATUS                Status;
+  EFI_KEY_DATA              KeyData1;
+  UINTN                     Index;
+  CHAR8                     *KnowGoodXml;
+  BASE_LIBRARY_JUMP_BUFFER  JumpBuf;
+  CONTEXT_DATA              *Ctx;
+
+  UT_ASSERT_NOT_NULL (Context);
+  Ctx = (CONTEXT_DATA *)Context;
+
+  will_return (MockClearScreen, EFI_SUCCESS);
+  will_return_always (MockSetAttribute, EFI_SUCCESS);
+
+  will_return (MockGetVariable, 0);
+  will_return (MockGetVariable, NULL);
+  will_return (MockGetVariable, EFI_NOT_FOUND);
+
+  // Expect the prints twice
+  expect_any (MockSetCursorPosition, Column);
+  expect_any (MockSetCursorPosition, Row);
+  will_return (MockSetCursorPosition, EFI_SUCCESS);
+
+  // Initial run
+  Status = SetupConfMgr ();
+  UT_ASSERT_NOT_EFI_ERROR (Status);
+  UT_ASSERT_EQUAL (mSetupConfState, SetupConfWait);
+
+  mSimpleTextInEx = &MockSimpleInput;
+
+  KeyData1.Key.UnicodeChar = '3';
+  KeyData1.Key.ScanCode    = SCAN_NULL;
+  will_return (MockReadKey, &KeyData1);
+
+  Status = SetupConfMgr ();
+  UT_ASSERT_NOT_EFI_ERROR (Status);
+  UT_ASSERT_EQUAL (mSetupConfState, SetupConfUpdateSerialHint);
+
+  Index       = 0;
+  KnowGoodXml = KNOWN_GOOD_VARLIST_XML;
+  while (KnowGoodXml[Index] != 0) {
+    KeyData1.Key.UnicodeChar = KnowGoodXml[Index];
+    KeyData1.Key.ScanCode    = SCAN_NULL;
+    will_return (MockReadKey, &KeyData1);
+    Status = SetupConfMgr ();
+    Index++;
+  }
+
+  KeyData1.Key.UnicodeChar = CHAR_CARRIAGE_RETURN;
+  KeyData1.Key.ScanCode    = SCAN_NULL;
+  will_return (MockReadKey, &KeyData1);
+
+  will_return_always (MockSetVariable, EFI_SUCCESS);
+
+  // first time through is delete
+  expect_memory (MockSetVariable, VariableName, L"COMPLEX_KNOB1a", StrSize (L"COMPLEX_KNOB1a"));
+  expect_memory (MockSetVariable, VendorGuid, &mKnown_Good_Xml_Guid_LE, sizeof (mKnown_Good_Xml_Guid_LE));
+  expect_value (MockSetVariable, DataSize, 0x00);
+  expect_value (MockSetVariable, Data, NULL);
+
+  expect_memory (MockSetVariable, VariableName, L"COMPLEX_KNOB1a", StrSize (L"COMPLEX_KNOB1a"));
+  expect_memory (MockSetVariable, VendorGuid, &mKnown_Good_Xml_Guid_LE, sizeof (mKnown_Good_Xml_Guid_LE));
+  expect_value (MockSetVariable, DataSize, 0x09);
+  expect_memory (MockSetVariable, Data, mKnown_Good_Xml_VarList_Entries[0], 0x09);
+
+  // first time through is delete
+  expect_memory (MockSetVariable, VariableName, L"INTEGER_KNOB", StrSize (L"INTEGER_KNOB"));
+  expect_memory (MockSetVariable, VendorGuid, &mKnown_Good_Xml_Guid_LE, sizeof (mKnown_Good_Xml_Guid_LE));
+  expect_value (MockSetVariable, DataSize, 0x00);
+  expect_value (MockSetVariable, Data, NULL);
+
+  expect_memory (MockSetVariable, VariableName, L"INTEGER_KNOB", StrSize (L"INTEGER_KNOB"));
+  expect_memory (MockSetVariable, VendorGuid, &mKnown_Good_Xml_Guid_LE, sizeof (mKnown_Good_Xml_Guid_LE));
+  expect_value (MockSetVariable, DataSize, 0x04);
+  expect_memory (MockSetVariable, Data, mKnown_Good_Xml_VarList_Entries[1], 0x04);
+
+  will_return (ResetCold, &JumpBuf);
+
+  if (!SetJump (&JumpBuf)) {
+    SetupConfMgr ();
+  }
+
+  return UNIT_TEST_PASSED;
+}
+
+/**
   Unit test for SetupConf page when selecting configure from serial and return in the middle.
 
   @param[in]  Context    [Optional] An optional parameter that enables:
@@ -1086,6 +1191,7 @@ UnitTestingEntry (
   AddTestCase (MiscTests, "Setup Configuration page select others should do nothing", "SelectOther", ConfAppSetupConfSelectOther, NULL, SetupConfCleanup, NULL);
   AddTestCase (MiscTests, "Setup Configuration page should setup configuration from USB", "SelectUsb", ConfAppSetupConfSelectUsb, SetupConfPrerequisite, SetupConfCleanup, &Context);
   AddTestCase (MiscTests, "Setup Configuration page should setup configuration from serial", "SelectSerial", ConfAppSetupConfSelectSerial, SetupConfPrerequisite, SetupConfCleanup, &Context);
+  AddTestCase (MiscTests, "Setup Configuration page should setup configuration from serial", "SelectSerialWithArbitrarySVD", ConfAppSetupConfSelectSerialWithArbitrarySVD, SetupConfPrerequisite, SetupConfCleanup, &Context);
   AddTestCase (MiscTests, "Setup Configuration page should return with ESC key during serial transport", "SelectSerial", ConfAppSetupConfSelectSerialEsc, NULL, SetupConfCleanup, NULL);
   AddTestCase (MiscTests, "Setup Configuration page should dump all configurations from serial", "ConfDump", ConfAppSetupConfDumpSerial, SetupConfPrerequisite, SetupConfCleanup, &Context);
   AddTestCase (MiscTests, "Setup Configuration page should ignore updating configurations when in non-mfg mode", "ConfNonMfg", ConfAppSetupConfNonMfg, NULL, SetupConfCleanup, NULL);

--- a/SetupDataPkg/ConfApp/UnitTest/ConfAppUnitTestCommon.c
+++ b/SetupDataPkg/ConfApp/UnitTest/ConfAppUnitTestCommon.c
@@ -95,9 +95,68 @@ MockGetVariable (
   return (EFI_STATUS)mock ();
 }
 
+/**
+  Mocked version of SetVariable.
+
+  @param[in]  VariableName       A Null-terminated string that is the name of the vendor's variable.
+                                 Each VariableName is unique for each VendorGuid. VariableName must
+                                 contain 1 or more characters. If VariableName is an empty string,
+                                 then EFI_INVALID_PARAMETER is returned.
+  @param[in]  VendorGuid         A unique identifier for the vendor.
+  @param[in]  Attributes         Attributes bitmask to set for the variable.
+  @param[in]  DataSize           The size in bytes of the Data buffer. Unless the EFI_VARIABLE_APPEND_WRITE or
+                                 EFI_VARIABLE_TIME_BASED_AUTHENTICATED_WRITE_ACCESS attribute is set, a size of zero
+                                 causes the variable to be deleted. When the EFI_VARIABLE_APPEND_WRITE attribute is
+                                 set, then a SetVariable() call with a DataSize of zero will not cause any change to
+                                 the variable value (the timestamp associated with the variable may be updated however
+                                 even if no new data value is provided,see the description of the
+                                 EFI_VARIABLE_AUTHENTICATION_2 descriptor below. In this case the DataSize will not
+                                 be zero since the EFI_VARIABLE_AUTHENTICATION_2 descriptor will be populated).
+  @param[in]  Data               The contents for the variable.
+
+  @retval EFI_SUCCESS            The firmware has successfully stored the variable and its data as
+                                 defined by the Attributes.
+  @retval EFI_INVALID_PARAMETER  An invalid combination of attribute bits, name, and GUID was supplied, or the
+                                 DataSize exceeds the maximum allowed.
+  @retval EFI_INVALID_PARAMETER  VariableName is an empty string.
+  @retval EFI_OUT_OF_RESOURCES   Not enough storage is available to hold the variable and its data.
+  @retval EFI_DEVICE_ERROR       The variable could not be retrieved due to a hardware error.
+  @retval EFI_WRITE_PROTECTED    The variable in question is read-only.
+  @retval EFI_WRITE_PROTECTED    The variable in question cannot be deleted.
+  @retval EFI_SECURITY_VIOLATION The variable could not be written due to EFI_VARIABLE_TIME_BASED_AUTHENTICATED_WRITE_ACCESS being set,
+                                 but the AuthInfo does NOT pass the validation check carried out by the firmware.
+
+  @retval EFI_NOT_FOUND          The variable trying to be updated or deleted was not found.
+
+**/
+STATIC
+EFI_STATUS
+EFIAPI
+MockSetVariable (
+  IN  CHAR16    *VariableName,
+  IN  EFI_GUID  *VendorGuid,
+  IN  UINT32    Attributes,
+  IN  UINTN     DataSize,
+  IN  VOID      *Data
+  )
+{
+  assert_non_null (VariableName);
+
+  DEBUG ((DEBUG_INFO, "%a Name: %s\n", __FUNCTION__, VariableName));
+  DUMP_HEX (DEBUG_ERROR, 0, VendorGuid, sizeof (VendorGuid), "OSDDEBUG: ");
+
+  check_expected (VariableName);
+  check_expected (VendorGuid);
+  check_expected (DataSize);
+  check_expected (Data);
+
+  return (EFI_STATUS)mock ();
+}
+
 ///
 /// Mock version of the UEFI Runtime Services Table
 ///
 EFI_RUNTIME_SERVICES  MockRuntime = {
-  .GetVariable = MockGetVariable
+  .GetVariable = MockGetVariable,
+  .SetVariable = MockSetVariable,
 };

--- a/SetupDataPkg/Test/Include/Good_Config_Data.h
+++ b/SetupDataPkg/Test/Include/Good_Config_Data.h
@@ -9,7 +9,8 @@
 #ifndef GOOD_CONFIG_DATA_H_
 #define GOOD_CONFIG_DATA_H_
 
-#define KNOWN_GOOD_XML  "<?xml version=\"1.0\" encoding=\"utf-8\"?><SettingsPacket xmlns=\"urn:UefiSettings-Schema\"><CreatedBy>Dfci Testcase Libraries</CreatedBy><CreatedOn>2022-08-15 18:12</CreatedOn><Version>1</Version><LowestSupportedVersion>1</LowestSupportedVersion><Settings><Setting><Id>Device.ConfigData.ConfigData</Id><Value>Q0ZHRBAAAACjAAAAABAAAC0AAA8AAAAAAAAAQQAABwAAAAAgAAAAAAAAADEAACgAAAAAAAAAAEEAABgAAAAARDMiEUYzIhGBAAAgAAAAAEczIhEBAgMEEREiIjMzREQiIhERREQzM2EAAAEAAAAATwAAgAAAAAAAAAABAAAAAJEAAAgAAAAAAAAAAAACAABGd3VJbWFnZS5iaW4AAAAAAAAAAA==</Value></Setting></Settings></SettingsPacket>"
+#define KNOWN_GOOD_XML          "<?xml version=\"1.0\" encoding=\"utf-8\"?><SettingsPacket xmlns=\"urn:UefiSettings-Schema\"><CreatedBy>Dfci Testcase Libraries</CreatedBy><CreatedOn>2022-08-15 18:12</CreatedOn><Version>1</Version><LowestSupportedVersion>1</LowestSupportedVersion><Settings><Setting><Id>Device.ConfigData.ConfigData</Id><Value>Q0ZHRBAAAACjAAAAABAAAC0AAA8AAAAAAAAAQQAABwAAAAAgAAAAAAAAADEAACgAAAAAAAAAAEEAABgAAAAARDMiEUYzIhGBAAAgAAAAAEczIhEBAgMEEREiIjMzREQiIhERREQzM2EAAAEAAAAATwAAgAAAAAAAAAABAAAAAJEAAAgAAAAAAAAAAAACAABGd3VJbWFnZS5iaW4AAAAAAAAAAA==</Value></Setting></Settings></SettingsPacket>"
+#define KNOWN_GOOD_VARLIST_XML  "<?xml version=\"1.0\" encoding=\"utf-8\"?><SettingsPacket xmlns=\"urn:UefiSettings-Schema\"><CreatedBy>Dfci Testcase Libraries</CreatedBy><CreatedOn>2022-12-07 14:21</CreatedOn><Version>1</Version><LowestSupportedVersion>1</LowestSupportedVersion><Settings><Setting><Id>COMPLEX_KNOB1a</Id><Value>HgAAAAkAAABDAE8ATQBQAEwARQBYAF8ASwBOAE8AQgAxAGEAAACf1D7+c7HtQZB2NWZh1GpCBwAAAAUFBQUFAAAAAHVtjRs=</Value></Setting><Setting><Id>INTEGER_KNOB</Id><Value>GgAAAAQAAABJAE4AVABFAEcARQBSAF8ASwBOAE8AQgAAAJ/UPv5zse1BkHY1ZmHUakIHAAAAaQAAAJgI1uY=</Value></Setting></Settings></SettingsPacket>"
 
 UINT8  mGood_Tag_0xF0[] = {
   0x00, 0x00, 0x00,
@@ -187,6 +188,11 @@ UINT8  mKnown_Good_VarList_Entries[9][22] = {
   { 0xF4, 0xFD, 0xB4, 0x3F }
 };
 
+UINT8  mKnown_Good_Xml_VarList_Entries[2][9] = {
+  { 0x05, 0x05, 0x05, 0x05, 0x05, 0x00, 0x00, 0x00, 0x00 },
+  { 0x69, 0x00, 0x00, 0x00 }
+};
+
 CHAR16  *mKnown_Good_VarList_Names[9] = {
   L"Device.ConfigData.TagID_00000280", L"Device.ConfigData.TagID_00000300", L"COMPLEX_KNOB1a", L"COMPLEX_KNOB1b",
   L"COMPLEX_KNOB2",                    L"INTEGER_KNOB",                     L"BOOLEAN_KNOB",   L"DOUBLE_KNOB", L"FLOAT_KNOB"
@@ -195,8 +201,13 @@ CHAR16  *mKnown_Good_VarList_Names[9] = {
 EFI_GUID  mKnown_Good_Yaml_Guid = {
   0x7664559F, 0x829E, 0x48E8, { 0xA4, 0x73, 0xF1, 0x2A, 0xDA, 0xD1, 0xDD, 0xD2 }
 };
+
 EFI_GUID  mKnown_Good_Xml_Guid = {
   0x9FD43EFE, 0x73B1, 0xED41, { 0x90, 0x76, 0x35, 0x66, 0x61, 0xD4, 0x6A, 0x42 }
+};
+
+EFI_GUID  mKnown_Good_Xml_Guid_LE = {
+  0xFE3ED49F, 0xB173, 0x41ED, { 0x90, 0x76, 0x35, 0x66, 0x61, 0xD4, 0x6A, 0x42 }
 };
 
 UINT32  mKnown_Good_VarList_DataSizes[9] = { 8, 4, 9, 9, 22, 4, 1, 8, 4 };


### PR DESCRIPTION
## Description

Currently, mu_feature_config is in a transition to an XML based backend. The current YAML based ConfApp expects SVDs with the IDs `"Device.ConfigData.*"`. However, the XML has no such restriction. In the case of the XML, we want to allow arbitrary SVD provided variables to be set, as this option is only provided in the manufacturing mode state (used often for bringup and debug).

This change leaves the YAML processing in place until more XML pieces are set to remove the remaining YAML pieces.

For each item, place an "x" in between `[` and `]` if true. Example: `[x]`.
_(you can also check items in the GitHub UI)_

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [x] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Tested with unit tests and in QemuQ35 by booting to the ConfApp in manufacturing mode, applying an SVD with arbitrary variables, rebooting to the EFI shell, using dmpstore to dump the variables to a file, applying that file in Config Editor and seeing that the current variable state matches what was provided in the SVD.

## Integration Instructions

N/A
