### PR TITLE
Remove update configuration from network packet option

### DIFF
--- a/SetupDataPkg/ConfApp/ConfApp.h
+++ b/SetupDataPkg/ConfApp/ConfApp.h
@@ -57,7 +57,6 @@ typedef enum SetupConfState_t_def {
   SetupConfInit,
   SetupConfWait,
   SetupConfUpdateUsb,
-  SetupConfUpdateNetwork,
   SetupConfUpdateSerialHint,
   SetupConfUpdateSerial,
   SetupConfDumpSerial,

--- a/SetupDataPkg/ConfApp/SetupConf.c
+++ b/SetupDataPkg/ConfApp/SetupConf.c
@@ -48,27 +48,18 @@ ConfAppKeyOptions  SetupConfStateOptions[SETUP_CONF_STATE_OPTIONS] = {
   {
     .KeyName             = L"2",
     .KeyNameTextAttr     = EFI_TEXT_ATTR (EFI_YELLOW, EFI_BLACK),
-    .Description         = L"Update from Network.",
-    .DescriptionTextAttr = EFI_TEXT_ATTR (EFI_WHITE, EFI_BLACK),
-    .UnicodeChar         = '2',
-    .ScanCode            = SCAN_NULL,
-    .EndState            = SetupConfUpdateNetwork
-  },
-  {
-    .KeyName             = L"3",
-    .KeyNameTextAttr     = EFI_TEXT_ATTR (EFI_YELLOW, EFI_BLACK),
     .Description         = L"Update from Serial Port.",
     .DescriptionTextAttr = EFI_TEXT_ATTR (EFI_WHITE, EFI_BLACK),
-    .UnicodeChar         = '3',
+    .UnicodeChar         = '2',
     .ScanCode            = SCAN_NULL,
     .EndState            = SetupConfUpdateSerialHint
   },
   {
-    .KeyName             = L"4",
+    .KeyName             = L"3",
     .KeyNameTextAttr     = EFI_TEXT_ATTR (EFI_YELLOW, EFI_BLACK),
     .Description         = L"Dump Current Configuration.\n",
     .DescriptionTextAttr = EFI_TEXT_ATTR (EFI_WHITE, EFI_BLACK),
-    .UnicodeChar         = '4',
+    .UnicodeChar         = '3',
     .ScanCode            = SCAN_NULL,
     .EndState            = SetupConfDumpSerial
   },
@@ -121,10 +112,7 @@ ResetGlobals (
   SetupConfStateOptions[0].EndState            = SetupConfUpdateUsb;
 
   SetupConfStateOptions[1].DescriptionTextAttr = EFI_TEXT_ATTR (EFI_WHITE, EFI_BLACK);
-  SetupConfStateOptions[1].EndState            = SetupConfUpdateNetwork;
-
-  SetupConfStateOptions[2].DescriptionTextAttr = EFI_TEXT_ATTR (EFI_WHITE, EFI_BLACK);
-  SetupConfStateOptions[2].EndState            = SetupConfUpdateSerialHint;
+  SetupConfStateOptions[1].EndState            = SetupConfUpdateSerialHint;
 
   mConfDataSize   = 0;
   mConfDataOffset = 0;
@@ -155,9 +143,6 @@ PrintOptions (
 
     SetupConfStateOptions[1].DescriptionTextAttr = EFI_TEXT_ATTR (EFI_DARKGRAY, EFI_BLACK);
     SetupConfStateOptions[1].EndState            = SetupConfError;
-
-    SetupConfStateOptions[2].DescriptionTextAttr = EFI_TEXT_ATTR (EFI_DARKGRAY, EFI_BLACK);
-    SetupConfStateOptions[2].EndState            = SetupConfError;
   }
 
   Status = PrintAvailableOptions (SetupConfStateOptions, SETUP_CONF_STATE_OPTIONS);
@@ -1046,12 +1031,6 @@ SetupConfMgr (
         ASSERT (FALSE);
       }
 
-      mSetupConfState = SetupConfExit;
-      break;
-    case SetupConfUpdateNetwork:
-      // TODO: This should not return to previous settings,
-      //       it should reboot if configuration changed
-      Print (L"This function is still under construction, please stay tuned for more features!\n");
       mSetupConfState = SetupConfExit;
       break;
     case SetupConfUpdateSerialHint:

--- a/SetupDataPkg/ConfApp/UnitTest/ConfAppSetupConfUnitTest.c
+++ b/SetupDataPkg/ConfApp/UnitTest/ConfAppSetupConfUnitTest.c
@@ -741,7 +741,7 @@ ConfAppSetupConfSelectSerial (
 
   mSimpleTextInEx = &MockSimpleInput;
 
-  KeyData1.Key.UnicodeChar = '3';
+  KeyData1.Key.UnicodeChar = '2';
   KeyData1.Key.ScanCode    = SCAN_NULL;
   will_return (MockReadKey, &KeyData1);
 
@@ -828,7 +828,7 @@ ConfAppSetupConfSelectSerialWithArbitrarySVD (
 
   mSimpleTextInEx = &MockSimpleInput;
 
-  KeyData1.Key.UnicodeChar = '3';
+  KeyData1.Key.UnicodeChar = '2';
   KeyData1.Key.ScanCode    = SCAN_NULL;
   will_return (MockReadKey, &KeyData1);
 
@@ -928,7 +928,7 @@ ConfAppSetupConfSelectSerialEsc (
 
   mSimpleTextInEx = &MockSimpleInput;
 
-  KeyData1.Key.UnicodeChar = '3';
+  KeyData1.Key.UnicodeChar = '2';
   KeyData1.Key.ScanCode    = SCAN_NULL;
   will_return (MockReadKey, &KeyData1);
 
@@ -1011,7 +1011,7 @@ ConfAppSetupConfDumpSerial (
 
   mSimpleTextInEx = &MockSimpleInput;
 
-  KeyData1.Key.UnicodeChar = '4';
+  KeyData1.Key.UnicodeChar = '3';
   KeyData1.Key.ScanCode    = SCAN_NULL;
   will_return (MockReadKey, &KeyData1);
 
@@ -1107,19 +1107,6 @@ ConfAppSetupConfNonMfg (
 
   // Selecting 2 should fail
   KeyData1.Key.UnicodeChar = '2';
-  KeyData1.Key.ScanCode    = SCAN_NULL;
-  will_return (MockReadKey, &KeyData1);
-
-  Status = SetupConfMgr ();
-  UT_ASSERT_NOT_EFI_ERROR (Status);
-  UT_ASSERT_EQUAL (mSetupConfState, SetupConfError);
-
-  Status = SetupConfMgr ();
-  UT_ASSERT_NOT_EFI_ERROR (Status);
-  UT_ASSERT_EQUAL (mSetupConfState, SetupConfWait);
-
-  // Selecting 3 should fail
-  KeyData1.Key.UnicodeChar = '3';
   KeyData1.Key.ScanCode    = SCAN_NULL;
   will_return (MockReadKey, &KeyData1);
 


### PR DESCRIPTION
## Description

Updating configuration from network will not be supported shortly. Remove this
option to clean up the page and avoid confusion.

For each item, place an "x" in between `[` and `]` if true. Example: `[x]`.
_(you can also check items in the GitHub UI)_

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [x] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

This change is tested on QEMU virtual platform.

## Integration Instructions

N/A. Removed unused and unimplemented feature option.
