### PR TITLE
Added python script to write dumpstore bin to variables from windows

### DIFF
--- a/SetupDataPkg/SetupDataPkg.ci.yaml
+++ b/SetupDataPkg/SetupDataPkg.ci.yaml
@@ -84,7 +84,9 @@
           "Malformatted",
           "PLATFORMID",
           "antlr",
-          "pywin"
+          "pywin",
+          "privilege",
+          "dmpstore"
         ],                           # words to extend to the dictionary for this package
         "IgnoreStandardPaths": [],   # Standard Plugin defined paths that should be ignore
         "AdditionalIncludePaths": [] # Additional paths to spell check (wildcards supported)

--- a/SetupDataPkg/Tools/WindowBinToNvram.py
+++ b/SetupDataPkg/Tools/WindowBinToNvram.py
@@ -1,0 +1,148 @@
+# @file
+#
+# Set a dumpbin formated set of variables to NVRAM
+#
+# Copyright (c), Microsoft Corporation
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+
+import os
+import sys
+import logging
+import argparse
+import struct
+import uuid
+import ctypes
+from SettingSupport.UefiVariablesSupportLib import UefiVariable  # noqa: E402
+
+gEfiGlobalVariableGuid ="8BE4DF61-93CA-11D2-AA0D-00E098032B8C"
+
+def option_parser():
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument(
+        "-guid",
+        "--guid",
+        dest="InputGuid",
+        type=str,
+        help="""Input Guid File""",
+    )
+
+    parser.add_argument(
+        "-l",
+        "--load",
+        dest="setting_file",
+        required=True,  
+        type=str,
+        default='""',
+        help="""Specify the input setting file""",
+    )
+
+    arguments = parser.parse_args()
+
+    if not os.path.isfile(arguments.setting_file):
+        print("Invalid input file: %s" % arguments.setting_file)
+        sys.exit(1)
+
+    return arguments
+
+#
+# Create an unpack statement formatted to address the variable length
+# paramters in the var store (Data and Unicode Name)
+def create_unpackstatement(NameStringSize, DataBufferSize):
+
+    #
+    # Dmpstore Format taken from AppendSingleVariableToFile() in 
+    # MU_BASECORE\ShellPkg\Library\UefiShellDebug1CommandsLib\DmpStore.c
+    # NameSize
+    # DataSize
+    # Name[NameSize]
+    # EFI_GUID
+    # Attributes
+    # Data[DataSize]
+    # CRC32
+
+    unpack_statement = "<II"
+    unpack_statement = unpack_statement + f"{NameStringSize}s"
+    unpack_statement = unpack_statement + "16s"
+    unpack_statement = unpack_statement + "I"
+    unpack_statement = unpack_statement + f"{DataBufferSize}s"
+    unpack_statement = unpack_statement + "I"
+
+    logging.debug(f"Created unpack statement {unpack_statement}")
+    return unpack_statement
+
+#
+# Using the passed byte array, extract the variable data and
+# write it into nvram
+#
+# Return the size of the un
+#
+def extract_single_var_from_file_and_write_nvram(var):
+    if len(var) > 8:
+        (NameSize, DataSize) = struct.unpack("<II", var[0:8])
+        
+        unpack_statement = create_unpackstatement(NameSize, DataSize)
+        result = struct.unpack(unpack_statement, var[0: struct.calcsize(unpack_statement)])
+
+        VarName = result[2].decode('utf16')
+        Guid = uuid.UUID(bytes_le=result[3])
+        Attributes = result[4]
+        Data = result[5]
+    
+ 
+        logging.debug(f"Found Variable: {VarName} {Guid} {Attributes}")
+
+        UefiVar = UefiVariable()
+        (rc, err, error_string) = UefiVar.SetUefiVar(
+            VarName,
+            Guid,
+            Data,
+            Attributes,
+        )
+        if rc == 0:
+            logging.debug(f"Error returned from SetUefiVar: {rc}")
+
+        return struct.calcsize(unpack_statement)
+    else:
+        logging.critical("var buffer was too small to be a valid dmstore")
+
+    return len(var)
+
+
+#
+# main script function
+#
+def main():
+    arguments = option_parser()
+
+    # read the entire file
+    with open(arguments.setting_file, "rb") as file:
+        var = file.read()
+
+        # go through the entire file parsing each dmpstore variable
+        start = 0;
+        while len(var[start:]) != 0:
+            start = start + extract_single_var_from_file_and_write_nvram(var[start:])
+
+    return 0
+
+
+if __name__ == "__main__":
+    # setup main console as logger
+    logger = logging.getLogger("")
+    logger.setLevel(logging.INFO)
+    formatter = logging.Formatter("%(levelname)s - %(message)s")
+    console = logging.StreamHandler()
+    console.setLevel(logging.CRITICAL)
+
+    # check the priviledge level and report error 
+    if not ctypes.windll.shell32.IsUserAnAdmin():
+        print("Administrator priviledge required. Please launch from an Administrator priviledge level.")
+        sys.exit(1)
+
+    # call main worker function
+    retcode = main()
+
+
+    logging.shutdown()
+    sys.exit(retcode)

--- a/SetupDataPkg/Tools/WriteConfVarListToUefiVars.py
+++ b/SetupDataPkg/Tools/WriteConfVarListToUefiVars.py
@@ -16,6 +16,7 @@ from SettingSupport.UefiVariablesSupportLib import UefiVariable
 
 gEfiGlobalVariableGuid = "8BE4DF61-93CA-11D2-AA0D-00E098032B8C"
 
+
 def option_parser():
     parser = argparse.ArgumentParser()
 
@@ -36,6 +37,7 @@ def option_parser():
         sys.exit(1)
 
     return arguments
+
 
 #
 # Create an unpack statement formatted to address the variable length
@@ -61,6 +63,7 @@ def create_unpackstatement(NameStringSize, DataBufferSize):
 
     logging.debug(f"Created unpack statement {unpack_statement}")
     return unpack_statement
+
 
 #
 # Using the passed byte array, extract the variable data and

--- a/SetupDataPkg/Tools/WriteConfVarListToUefiVars.py
+++ b/SetupDataPkg/Tools/WriteConfVarListToUefiVars.py
@@ -1,6 +1,6 @@
 # @file
 #
-# Set a dumpbin formatted set of variables to NVRAM
+# Set a dmpstore formatted set of variables to NVRAM
 #
 # Copyright (c), Microsoft Corporation
 # SPDX-License-Identifier: BSD-2-Clause-Patent

--- a/SetupDataPkg/Tools/WriteConfVarListToUefiVars.py
+++ b/SetupDataPkg/Tools/WriteConfVarListToUefiVars.py
@@ -135,9 +135,9 @@ if __name__ == "__main__":
     console = logging.StreamHandler()
     console.setLevel(logging.CRITICAL)
 
-    # check the priviledge level and report error
+    # check the privilege level and report error
     if not ctypes.windll.shell32.IsUserAnAdmin():
-        print("Administrator priviledge required. Please launch from an Administrator priviledge level.")
+        print("Administrator privilege required. Please launch from an Administrator privilege level.")
         sys.exit(1)
 
     # call main worker function

--- a/SetupDataPkg/Tools/WriteConfVarListToUefiVars.py
+++ b/SetupDataPkg/Tools/WriteConfVarListToUefiVars.py
@@ -1,6 +1,6 @@
 # @file
 #
-# Set a dumpbin formated set of variables to NVRAM
+# Set a dumpbin formatted set of variables to NVRAM
 #
 # Copyright (c), Microsoft Corporation
 # SPDX-License-Identifier: BSD-2-Clause-Patent
@@ -41,8 +41,8 @@ def option_parser():
 
 #
 # Create an unpack statement formatted to address the variable length
-# paramters in the var store (Data and Unicode Name)
-def create_unpackstatement(NameStringSize, DataBufferSize):
+# parameters in the var store (Data and Unicode Name)
+def create_unpack_statement(NameStringSize, DataBufferSize):
     #
     # Dmpstore Format taken from AppendSingleVariableToFile() in
     # ShellPkg\Library\UefiShellDebug1CommandsLib\DmpStore.c
@@ -76,7 +76,7 @@ def extract_single_var_from_file_and_write_nvram(var):
     if len(var) > 8:
         (NameSize, DataSize) = struct.unpack("<II", var[0:8])
 
-        unpack_statement = create_unpackstatement(NameSize, DataSize)
+        unpack_statement = create_unpack_statement(NameSize, DataSize)
 
         # check that the input byte array has at least enough space for unpack statement
         if struct.calcsize(unpack_statement) > len(var):
@@ -104,7 +104,7 @@ def extract_single_var_from_file_and_write_nvram(var):
 
         return struct.calcsize(unpack_statement)
     else:
-        logging.critical("var buffer was too small to be a valid dmstore")
+        logging.critical("var buffer was too small to be a valid dmpstore")
 
     return len(var)
 


### PR DESCRIPTION
## Description

The output from ConfigUtility's  "Save Full Config Data to binary" creates binaries in UefiShell dmpstore format.
They can be directly consumed by the uefi shell.

This script allows the ability to set the information into NVRAM from windows.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested
Script was run from windows and data binary was written into the system's NVRAM.

`C:\Windows\System32>py -3 C:\Code\mu_feature_config\SetupDataPkg\Tools\WindowBinToNvram.py -l c:\Code\MySettings1.bin

INFO:root:Calling SetFirmwareEnvironmentVariableEx( name='Device.ConfigData.TagID_00000010 ', GUID='{7664559f-829e-48e8-a473-f12adad1ddd2}', length=0x1, attributes=0x3 )..

INFO:root:Calling SetFirmwareEnvironmentVariableEx( name='Device.ConfigData.TagID_00000020 ', GUID='{7664559f-829e-48e8-a473-f12adad1ddd2}', length=0x5D, attributes=0x3 )..

INFO:root:Calling SetFirmwareEnvironmentVariableEx( name='Device.ConfigData.TagID_00000030 ', GUID='{7664559f-829e-48e8-a473-f12adad1ddd2}', length=0xA, attributes=0x3 )..

INFO:root:Calling SetFirmwareEnvironmentVariableEx( name='Device.ConfigData.TagID_00000040 ', GUID='{7664559f-829e-48e8-a473-f12adad1ddd2}', length=0x27, attributes=0x3 )..

INFO:root:Calling SetFirmwareEnvironmentVariableEx( name='Device.ConfigData.TagID_00000050 ', GUID='{7664559f-829e-48e8-a473-f12adad1ddd2}', length=0x8B, attributes=0x3 )..

INFO:root:Calling SetFirmwareEnvironmentVariableEx( name='Device.ConfigData.TagID_00000060 ', GUID='{7664559f-829e-48e8-a473-f12adad1ddd2}', length=0x3, attributes=0x3 )..

INFO:root:Calling SetFirmwareEnvironmentVariableEx( name='Device.ConfigData.TagID_00000080 ', GUID='{7664559f-829e-48e8-a473-f12adad1ddd2}', length=0x6, attributes=0x3 )..`



## Integration Instructions
N/A