### PR TITLE
Fixing dump option from ConfApp

### DIFF
--- a/SetupDataPkg/ConfApp/SetupConf.c
+++ b/SetupDataPkg/ConfApp/SetupConf.c
@@ -853,7 +853,7 @@ CreateXmlStringFromCurrentSettings (
         goto EXIT;
       }
 
-      Status   = gRT->GetNextVariableName (&NewNameSize, Name, &Guid);
+      Status = gRT->GetNextVariableName (&NewNameSize, Name, &Guid);
     }
 
     NameSize = NewNameSize;

--- a/SetupDataPkg/ConfApp/SetupConf.c
+++ b/SetupDataPkg/ConfApp/SetupConf.c
@@ -854,8 +854,8 @@ CreateXmlStringFromCurrentSettings (
       }
 
       Status   = gRT->GetNextVariableName (&NewNameSize, Name, &Guid);
-      NameSize = NewNameSize;
     }
+    NameSize = NewNameSize;
 
     if (Status == EFI_NOT_FOUND) {
       break;

--- a/SetupDataPkg/ConfApp/SetupConf.c
+++ b/SetupDataPkg/ConfApp/SetupConf.c
@@ -855,6 +855,7 @@ CreateXmlStringFromCurrentSettings (
 
       Status   = gRT->GetNextVariableName (&NewNameSize, Name, &Guid);
     }
+
     NameSize = NewNameSize;
 
     if (Status == EFI_NOT_FOUND) {

--- a/SetupDataPkg/ConfApp/SetupConf.c
+++ b/SetupDataPkg/ConfApp/SetupConf.c
@@ -974,6 +974,9 @@ CreateXmlStringFromCurrentSettings (
 
       // They should still match in size...
       ASSERT (Offset == NeededSize);
+
+      // Then pacify the value of DataSize used below
+      DataSize = NeededSize;
     }
 
     // First encode the binary blob

--- a/pip-requirements.txt
+++ b/pip-requirements.txt
@@ -13,7 +13,7 @@
 ##
 
 edk2-pytool-library~=0.12.1 # MU_CHANGE - update to 0.11.6 or later
-edk2-pytool-extensions~=0.20.1 # MU_CHANGE - update to 0.19.1 or later
+edk2-pytool-extensions~=0.21.0 # MU_CHANGE - update to 0.19.1 or later
 edk2-basetools==0.1.29 # MU_CHANGE - update to 0.1.29 or later
 antlr4-python3-runtime==4.11.1
 xmlschema==2.1.1 # MU_CHANGE - update to 2.0.1 or later


### PR DESCRIPTION
# Preface

Please ensure you have read the [contribution docs](https://github.com/microsoft/mu/blob/master/CONTRIBUTING.md) prior
to submitting the pull request. In particular,
[pull request guidelines](https://github.com/microsoft/mu/blob/master/CONTRIBUTING.md#pull-request-best-practices).

## Description

The existing code path passed in the incorrect data length using the size of UEFI variable raw data length. This change updated it to use the full base64 encoded xml string to display to the serial port.

Another issue is that the name size variable is not updated until a larger one hits, which makes the code copied extra garbage bytes to the end data.

For each item, place an "x" in between `[` and `]` if true. Example: `[x]`.
_(you can also check items in the GitHub UI)_

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Tested on Qemu Q35 virtual platform together with latest ConfigEditor.py in this repo.

## Integration Instructions

N/A
