### PR TITLE
Add Newline to KnobService.py Output

### DIFF
--- a/SetupDataPkg/Tools/KnobService.py
+++ b/SetupDataPkg/Tools/KnobService.py
@@ -694,7 +694,7 @@ def generate_cached_implementation(schema, header_path, efi_type=False):
                 out.write("{} config_set_{}({} value) {{".format(
                     get_type_string('bool', efi_type),
                     knob.name,
-                    knob.format.c_type))
+                    knob.format.c_type) + get_line_ending(efi_type))
                 out.write(get_spacing_string(efi_type) + "return set_knob_value(KNOB_{}, &value);".format(
                     knob.name
                 ) + get_line_ending(efi_type))


### PR DESCRIPTION
# Preface

Please ensure you have read the [contribution docs](https://github.com/microsoft/mu/blob/master/CONTRIBUTING.md) prior
to submitting the pull request. In particular,
[pull request guidelines](https://github.com/microsoft/mu/blob/master/CONTRIBUTING.md#pull-request-best-practices).

## Description

This fixes bug [107](https://github.com/microsoft/mu_feature_config/issues/107). Simple whitespace fix, no code functionality change. The example in the bug now prints:

```
#ifdef CONFIG_SET_VARIABLES
// Set the current value of the example knob
bool config_set_example(bool value) {
    return set_knob_value(KNOB_example, &value);
}
```

For each item, place an "x" in between `[` and `]` if true. Example: `[x]`.
_(you can also check items in the GitHub UI)_

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Tested by running KnobService.py locally on the XML included in the bug example.

## Integration Instructions

N/A
