### PR TITLE
Fix a TypeError when generating knob profiles

### DIFF
--- a/SetupDataPkg/Tools/KnobService.py
+++ b/SetupDataPkg/Tools/KnobService.py
@@ -739,8 +739,8 @@ def generate_profiles(schema, profile_header_path, profile_paths, efi_type):
                 if knob.value is not None:
                     override_count = override_count + 1
                     out.write(get_spacing_string(efi_type) + "{} {};".format(
-                        knob.format.c_type,
-                        knob.name), + get_line_ending(efi_type))
+                        get_type_string(knob.format.c_type, efi_type),
+                        knob.name) + get_line_ending(efi_type))
             out.write("}} {}{}{};".format(
                 naming_convention_filter("profile_", True, efi_type),
                 base_name,


### PR DESCRIPTION
# Preface

Please ensure you have read the [contribution docs](https://github.com/microsoft/mu/blob/master/CONTRIBUTING.md) prior
to submitting the pull request. In particular,
[pull request guidelines](https://github.com/microsoft/mu/blob/master/CONTRIBUTING.md#pull-request-best-practices).

## Description

Fix a misformatted string in KnobService.py (generate_profiles) where a
stray comma makes Python misinterpret the `+` sign as a unary arithmetic
operation on a string. KnobService.py ends up crashing with  the
following exception:

`TypeError: bad operand type for unary +: 'str'`

Also add a missing UEFI type conversion for the knob being overridden.

For each item, place an "x" in between `[` and `]` if true. Example: `[x]`.
_(you can also check items in the GitHub UI)_

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Tested by running KnobService.py locally to verify that profile
overrides are generated successfully.

## Integration Instructions

N/A.

Pulling the latest version of mu_feature_config will automatically
include this fix.