### PR TITLE
Change to UINT32 fields

### DIFF
--- a/SetupDataPkg/Include/ConfigStdStructDefs.h
+++ b/SetupDataPkg/Include/ConfigStdStructDefs.h
@@ -22,11 +22,11 @@ typedef struct {
   UINTN                 Knob;
   CONST VOID            *DefaultValueAddress;
   VOID                  *CacheValueAddress;
-  UINTN                 ValueSize;
+  UINT32                ValueSize;
   CONST CHAR8           *Name;
-  UINTN                 NameSize;
+  UINT32                NameSize;
   EFI_GUID              VendorNamespace;
-  INTN                  Attributes;
+  UINT32                Attributes;
   KNOB_VALIDATION_FN    *Validator;
 } KNOB_DATA;
 


### PR DESCRIPTION
# Preface

Please ensure you have read the [contribution docs](https://github.com/microsoft/mu/blob/master/CONTRIBUTING.md) prior
to submitting the pull request. In particular,
[pull request guidelines](https://github.com/microsoft/mu/blob/master/CONTRIBUTING.md#pull-request-best-practices).

## Description

This change was missed on the PR integrating this header file. Make these values UINT32 to match the sizes expected in binary format and in consumers of this header.

For each item, place an "x" in between `[` and `]` if true. Example: `[x]`.
_(you can also check items in the GitHub UI)_

- [x] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Tested in mu_tiano_platforms using the mu_oem_sample driver that consumes this.

## Integration Instructions
 
N/A
