### PR TITLE
Correctly Print Validation Function for Standalone Enums in KnobService.py

### DIFF
--- a/SetupDataPkg/Tools/KnobService.py
+++ b/SetupDataPkg/Tools/KnobService.py
@@ -743,7 +743,7 @@ def generate_cached_implementation(schema, header_path, efi_type=False):
                                     subknob.format.name,
                                     naming_convention_filter("value", False, efi_type)
                                 ))
-                                
+
                             out.write(get_line_ending(efi_type))
                             out.write(get_spacing_string(efi_type, num=2))
                             out.write("return {};".format(

--- a/SetupDataPkg/Tools/KnobService.py
+++ b/SetupDataPkg/Tools/KnobService.py
@@ -725,15 +725,26 @@ def generate_cached_implementation(schema, header_path, efi_type=False):
                 for subknob in knob.subknobs:
                     if subknob.leaf:
                         path = subknob.name[len(knob.name):]
+                        print("OSDDEBUG path: ", subknob.name.find('.'))
                         define_name = subknob.name.replace('[', '_').replace(']', '_').replace('.', '__')
                         if isinstance(subknob.format, VariableList.EnumFormat):
-                            out.write(get_spacing_string(efi_type) + "if (!{}{}({}->{})) {{".format(
-                                naming_convention_filter("validate_enum_value_", False, efi_type),
-                                subknob.format.name,
-                                naming_convention_filter("value", False, efi_type),
-                                # don't take the '.'
-                                path[1:]
-                            ))
+                            if path.find('.') != -1:
+                                # this is an enum inside of a struct
+                                out.write(get_spacing_string(efi_type) + "if (!{}{}({}->{})) {{".format(
+                                    naming_convention_filter("validate_enum_value_", False, efi_type),
+                                    subknob.format.name,
+                                    naming_convention_filter("value", False, efi_type),
+                                    # don't take the '.'
+                                    path[1:]
+                                ))
+                            else:
+                                # this is a standalone enum knob
+                                out.write(get_spacing_string(efi_type) + "if (!{}{}(*{})) {{".format(
+                                    naming_convention_filter("validate_enum_value_", False, efi_type),
+                                    subknob.format.name,
+                                    naming_convention_filter("value", False, efi_type)
+                                ))
+                                
                             out.write(get_line_ending(efi_type))
                             out.write(get_spacing_string(efi_type, num=2))
                             out.write("return {};".format(

--- a/SetupDataPkg/Tools/KnobService.py
+++ b/SetupDataPkg/Tools/KnobService.py
@@ -725,7 +725,6 @@ def generate_cached_implementation(schema, header_path, efi_type=False):
                 for subknob in knob.subknobs:
                     if subknob.leaf:
                         path = subknob.name[len(knob.name):]
-                        print("OSDDEBUG path: ", subknob.name.find('.'))
                         define_name = subknob.name.replace('[', '_').replace(']', '_').replace('.', '__')
                         if isinstance(subknob.format, VariableList.EnumFormat):
                             if path.find('.') != -1:


### PR DESCRIPTION
# Preface

Please ensure you have read the [contribution docs](https://github.com/microsoft/mu/blob/master/CONTRIBUTING.md) prior
to submitting the pull request. In particular,
[pull request guidelines](https://github.com/microsoft/mu/blob/master/CONTRIBUTING.md#pull-request-best-practices).

## Description

There is currently a bug in KnobService.py where standalone enum knobs are not printed correctly in the validation functions, as it is only expecting enums inside of structs. This PR fixes that logic so builds are not broken with standalone enum knobs.

For each item, place an "x" in between `[` and `]` if true. Example: `[x]`.
_(you can also check items in the GitHub UI)_

- [x] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Tested on QemuSbsaPkg while integrating config there.

## Integration Instructions

N/A.
