### PR TITLE
Fixing GenBin command line option

### DIFF
--- a/SetupDataPkg/Tools/GenNCCfgData.py
+++ b/SetupDataPkg/Tools/GenNCCfgData.py
@@ -33,7 +33,7 @@ from VariableList import (
 
 class CGenNCCfgData:
     def __init__(self, file_name):
-        self.initialize(file_name)
+        self.load_xml(file_name)
 
     def initialize(self, file_name):
         self._cfg_page = {"root": {"title": "", "child": []}}
@@ -333,7 +333,6 @@ def main():
         usage()
         return 1
 
-    gen_cfg_data = CGenNCCfgData()
     command = sys.argv[1].upper()
     out_file = sys.argv[3]
 
@@ -356,7 +355,7 @@ def main():
             if len(file_list) >= 3:
                 cfg_bin_file2 = file_list[2]
 
-    gen_cfg_data.load_xml(xml_file)
+    gen_cfg_data = CGenNCCfgData(xml_file)
 
     if csv_file:
         gen_cfg_data.override_default_value(csv_file)

--- a/SetupDataPkg/Tools/GenNCCfgData_test.py
+++ b/SetupDataPkg/Tools/GenNCCfgData_test.py
@@ -17,16 +17,17 @@ class UncoreCfgUnitTests(unittest.TestCase):
 
     # This is a general test for loading xml file and make sure all pages are there
     def test_xml_knob_to_page(self):
-        cdata = CGenNCCfgData("sampleschema.xml")
         if os.path.exists("sampleschema.xml"):
             # Load for local testing
-            cdata.load_xml("sampleschema.xml")
+            sample_path = "sampleschema.xml"
         elif os.path.exists("SetupDataPkg/Tools/sampleschema.xml"):
             # Load for Linux CI
-            cdata.load_xml("SetupDataPkg/Tools/sampleschema.xml")
+            sample_path = "SetupDataPkg/Tools/sampleschema.xml"
         else:
             # Load for Windows CI
-            cdata.load_xml("SetupDataPkg\\Tools\\sampleschema.xml")
+            sample_path = "SetupDataPkg\\Tools\\sampleschema.xml"
+
+        cdata = CGenNCCfgData(sample_path)
 
         self.assertIsNotNone(cdata.schema)
         self.assertIsNotNone(cdata.schema.knobs)
@@ -62,16 +63,17 @@ class UncoreCfgUnitTests(unittest.TestCase):
 
     # This is a test for loading xml file and make sure all subknobs have a shim instance for rendering
     def test_xml_subknob_to_shim(self):
-        cdata = CGenNCCfgData("sampleschema.xml")
         if os.path.exists("sampleschema.xml"):
             # Load for local testing
-            cdata.load_xml("sampleschema.xml")
+            sample_path = "sampleschema.xml"
         elif os.path.exists("SetupDataPkg/Tools/sampleschema.xml"):
             # Load for Linux CI
-            cdata.load_xml("SetupDataPkg/Tools/sampleschema.xml")
+            sample_path = "SetupDataPkg/Tools/sampleschema.xml"
         else:
             # Load for Windows CI
-            cdata.load_xml("SetupDataPkg\\Tools\\sampleschema.xml")
+            sample_path = "SetupDataPkg\\Tools\\sampleschema.xml"
+
+        cdata = CGenNCCfgData(sample_path)
 
         subknob_list = cdata.schema.subknobs
         for entry in cdata.knob_shim:
@@ -92,16 +94,17 @@ class UncoreCfgUnitTests(unittest.TestCase):
 
     # Retrieving all items with a given page_id, should return all the subknobs under that id
     def test_xml_get_cfg_list(self):
-        cdata = CGenNCCfgData("sampleschema.xml")
         if os.path.exists("sampleschema.xml"):
             # Load for local testing
-            cdata.load_xml("sampleschema.xml")
+            sample_path = "sampleschema.xml"
         elif os.path.exists("SetupDataPkg/Tools/sampleschema.xml"):
             # Load for Linux CI
-            cdata.load_xml("SetupDataPkg/Tools/sampleschema.xml")
+            sample_path = "SetupDataPkg/Tools/sampleschema.xml"
         else:
             # Load for Windows CI
-            cdata.load_xml("SetupDataPkg\\Tools\\sampleschema.xml")
+            sample_path = "SetupDataPkg\\Tools\\sampleschema.xml"
+
+        cdata = CGenNCCfgData(sample_path)
 
         # Get the whole set
         ret = cdata.get_cfg_list()
@@ -129,16 +132,17 @@ class UncoreCfgUnitTests(unittest.TestCase):
 
     # Retrieving values for all shim items, should return the same value from the underlying knob
     def test_xml_get_cfg_item_value(self):
-        cdata = CGenNCCfgData("sampleschema.xml")
         if os.path.exists("sampleschema.xml"):
             # Load for local testing
-            cdata.load_xml("sampleschema.xml")
+            sample_path = "sampleschema.xml"
         elif os.path.exists("SetupDataPkg/Tools/sampleschema.xml"):
             # Load for Linux CI
-            cdata.load_xml("SetupDataPkg/Tools/sampleschema.xml")
+            sample_path = "SetupDataPkg/Tools/sampleschema.xml"
         else:
             # Load for Windows CI
-            cdata.load_xml("SetupDataPkg\\Tools\\sampleschema.xml")
+            sample_path = "SetupDataPkg\\Tools\\sampleschema.xml"
+
+        cdata = CGenNCCfgData(sample_path)
 
         # Get only a struct knob
         for each in cdata.knob_shim:
@@ -147,16 +151,17 @@ class UncoreCfgUnitTests(unittest.TestCase):
 
     # Reformat a value string should return properly
     def test_xml_reformat_value_str(self):
-        cdata = CGenNCCfgData("sampleschema.xml")
         if os.path.exists("sampleschema.xml"):
             # Load for local testing
-            cdata.load_xml("sampleschema.xml")
+            sample_path = "sampleschema.xml"
         elif os.path.exists("SetupDataPkg/Tools/sampleschema.xml"):
             # Load for Linux CI
-            cdata.load_xml("SetupDataPkg/Tools/sampleschema.xml")
+            sample_path = "SetupDataPkg/Tools/sampleschema.xml"
         else:
             # Load for Windows CI
-            cdata.load_xml("SetupDataPkg\\Tools\\sampleschema.xml")
+            sample_path = "SetupDataPkg\\Tools\\sampleschema.xml"
+
+        cdata = CGenNCCfgData(sample_path)
 
         # Run on an integer knob
         ret = cdata.get_item_by_path('FE3ED49F-B173-41ED-9076-356661D46A42.INTEGER_KNOB')
@@ -187,16 +192,17 @@ class UncoreCfgUnitTests(unittest.TestCase):
 
     # Get value should return subknob value, matching the corresponding shim entry
     def test_xml_get_value(self):
-        cdata = CGenNCCfgData("sampleschema.xml")
         if os.path.exists("sampleschema.xml"):
             # Load for local testing
-            cdata.load_xml("sampleschema.xml")
+            sample_path = "sampleschema.xml"
         elif os.path.exists("SetupDataPkg/Tools/sampleschema.xml"):
             # Load for Linux CI
-            cdata.load_xml("SetupDataPkg/Tools/sampleschema.xml")
+            sample_path = "SetupDataPkg/Tools/sampleschema.xml"
         else:
             # Load for Windows CI
-            cdata.load_xml("SetupDataPkg\\Tools\\sampleschema.xml")
+            sample_path = "SetupDataPkg\\Tools\\sampleschema.xml"
+
+        cdata = CGenNCCfgData(sample_path)
 
         # Get only a struct knob
         for each in cdata.knob_shim:
@@ -205,16 +211,17 @@ class UncoreCfgUnitTests(unittest.TestCase):
 
     # Set item value should update the subknob value
     def test_xml_set_item_value(self):
-        cdata = CGenNCCfgData("sampleschema.xml")
         if os.path.exists("sampleschema.xml"):
             # Load for local testing
-            cdata.load_xml("sampleschema.xml")
+            sample_path = "sampleschema.xml"
         elif os.path.exists("SetupDataPkg/Tools/sampleschema.xml"):
             # Load for Linux CI
-            cdata.load_xml("SetupDataPkg/Tools/sampleschema.xml")
+            sample_path = "SetupDataPkg/Tools/sampleschema.xml"
         else:
             # Load for Windows CI
-            cdata.load_xml("SetupDataPkg\\Tools\\sampleschema.xml")
+            sample_path = "SetupDataPkg\\Tools\\sampleschema.xml"
+
+        cdata = CGenNCCfgData(sample_path)
 
         # Run on an integer knob
         ret = cdata.get_item_by_path('FE3ED49F-B173-41ED-9076-356661D46A42.INTEGER_KNOB')
@@ -251,16 +258,17 @@ class UncoreCfgUnitTests(unittest.TestCase):
 
     # Get item options should reflect the available enum or boolean options
     def test_xml_get_cfg_item_options(self):
-        cdata = CGenNCCfgData("sampleschema.xml")
         if os.path.exists("sampleschema.xml"):
             # Load for local testing
-            cdata.load_xml("sampleschema.xml")
+            sample_path = "sampleschema.xml"
         elif os.path.exists("SetupDataPkg/Tools/sampleschema.xml"):
             # Load for Linux CI
-            cdata.load_xml("SetupDataPkg/Tools/sampleschema.xml")
+            sample_path = "SetupDataPkg/Tools/sampleschema.xml"
         else:
             # Load for Windows CI
-            cdata.load_xml("SetupDataPkg\\Tools\\sampleschema.xml")
+            sample_path = "SetupDataPkg\\Tools\\sampleschema.xml"
+
+        cdata = CGenNCCfgData(sample_path)
 
         # Run on an enum knob
         ret = cdata.get_item_by_path('FE3ED49F-B173-41ED-9076-356661D46A42.COMPLEX_KNOB1b.mode')
@@ -276,16 +284,17 @@ class UncoreCfgUnitTests(unittest.TestCase):
 
     # Sync function should sync up the value for shim and underlying knobs
     def test_xml_sync_shim_and_schema(self):
-        cdata = CGenNCCfgData("sampleschema.xml")
         if os.path.exists("sampleschema.xml"):
             # Load for local testing
-            cdata.load_xml("sampleschema.xml")
+            sample_path = "sampleschema.xml"
         elif os.path.exists("SetupDataPkg/Tools/sampleschema.xml"):
             # Load for Linux CI
-            cdata.load_xml("SetupDataPkg/Tools/sampleschema.xml")
+            sample_path = "SetupDataPkg/Tools/sampleschema.xml"
         else:
             # Load for Windows CI
-            cdata.load_xml("SetupDataPkg\\Tools\\sampleschema.xml")
+            sample_path = "SetupDataPkg\\Tools\\sampleschema.xml"
+
+        cdata = CGenNCCfgData(sample_path)
 
         # Run on an integer knob
         ret = cdata.get_item_by_path('FE3ED49F-B173-41ED-9076-356661D46A42.INTEGER_KNOB')


### PR DESCRIPTION
# Preface

Please ensure you have read the [contribution docs](https://github.com/microsoft/mu/blob/master/CONTRIBUTING.md) prior
to submitting the pull request. In particular,
[pull request guidelines](https://github.com/microsoft/mu/blob/master/CONTRIBUTING.md#pull-request-best-practices).

## Description

A recent change in the configuration class start to require xml to be supplied from the initialization routine, which stops the command line option from generating binaries with given xml file path.

This change fixed the missing input error.

For each item, place an "x" in between `[` and `]` if true. Example: `[x]`.
_(you can also check items in the GitHub UI)_

- [x] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

This was tested manually using sample xml.

## Integration Instructions

N/A
