### PR TITLE
Do not return None when `efi_var` is allocated properly

### DIFF
--- a/SetupDataPkg/Tools/ReadUefiVarsToConfVarList.py
+++ b/SetupDataPkg/Tools/ReadUefiVarsToConfVarList.py
@@ -55,7 +55,9 @@ def option_parser():
 def read_variable_into_variable_list(uefi_var, name, namespace):
     (rc, var, _) = uefi_var.GetUefiVar(name, namespace)
     if rc != 0:
-        logging.error(f"Error returned from GetUefiVar: {rc} on Name: {name}, Guid: {namespace}")
+        if rc != UefiVariable.ERROR_ENVVAR_NOT_FOUND:
+            # only log the errors other than EFI_NOT_FOUND, because not found is normal in this case...
+            logging.error(f"Error returned from GetUefiVar: {rc} on Name: {name}, Guid: {namespace}")
         return b''
 
     variable = UEFIVariable(name, namespace, var)
@@ -102,8 +104,7 @@ def main():
         if len(ret) != 0:
             file.write(ret)
         else:
-            logging.error("No variables found!!!")
-            return 1
+            logging.warning("No variables found!!!")
     return 0
 
 

--- a/SetupDataPkg/Tools/SettingSupport/UefiVariablesSupportLib.py
+++ b/SetupDataPkg/Tools/SettingSupport/UefiVariablesSupportLib.py
@@ -26,6 +26,8 @@ EFI_VAR_MAX_BUFFER_SIZE = 1024 * 1024
 
 
 class UefiVariable(object):
+    ERROR_ENVVAR_NOT_FOUND = 0xcb
+
     def __init__(self):
         # enable required SeSystemEnvironmentPrivilege privilege
         privilege = win32security.LookupPrivilegeValue(
@@ -127,10 +129,11 @@ class UefiVariable(object):
             )
         if (0 == length) or (efi_var is None):
             err = kernel32.GetLastError()
-            logging.error(
-                "GetFirmwareEnvironmentVariable[Ex] failed (GetLastError = 0x%x)" % err
-            )
-            logging.error(WinError())
+            if err != 0 and err != UefiVariable.ERROR_ENVVAR_NOT_FOUND:
+                logging.error(
+                    "GetFirmwareEnvironmentVariable[Ex] failed (GetLastError = 0x%x)" % err
+                )
+                logging.error(WinError())
             if efi_var is None:
                 return (err, None, WinError(err))
         return (err, efi_var[:length], WinError(err))

--- a/SetupDataPkg/Tools/SettingSupport/UefiVariablesSupportLib.py
+++ b/SetupDataPkg/Tools/SettingSupport/UefiVariablesSupportLib.py
@@ -131,8 +131,9 @@ class UefiVariable(object):
                 "GetFirmwareEnvironmentVariable[Ex] failed (GetLastError = 0x%x)" % err
             )
             logging.error(WinError())
-            return (err, None, WinError(err))
-        return (err, efi_var[:length], None)
+            if efi_var is None:
+                return (err, None, WinError(err))
+        return (err, efi_var[:length], WinError(err))
 
     #
     # Function to get all variable names


### PR DESCRIPTION
# Preface

Please ensure you have read the [contribution docs](https://github.com/microsoft/mu/blob/master/CONTRIBUTING.md) prior
to submitting the pull request. In particular,
[pull request guidelines](https://github.com/microsoft/mu/blob/master/CONTRIBUTING.md#pull-request-best-practices).

## Description

This change added an error handling for `GetFirmwareEnvironmentVariable`, where the returned UEFI variable buffer will only be None when the buffer allocation failed.

It also removed the printouts when the OS API returned `EFI_NOT_FOUND`, because it would happen as a normal use case.

For each item, place an "x" in between `[` and `]` if true. Example: `[x]`.
_(you can also check items in the GitHub UI)_

- [x] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

This change was tested on proprietary hardware platform.

## Integration Instructions

N/A
