### PR TITLE
Split enum name validation from identifer validation support. Allow e…

### DIFF
--- a/SetupDataPkg/Tools/VariableList.py
+++ b/SetupDataPkg/Tools/VariableList.py
@@ -96,10 +96,14 @@ def split_braces(string_object):
 
 
 # Checks to see if a token is a valid C identifier
-def is_valid_name(token):
+def is_valid_c_identifier(token):
     matches = re.findall("^[a-zA-Z_][0-9a-zA-Z_]*$", token)
     return len(matches) == 1
 
+# checks if an enum is valid
+def is_valid_name(token):
+    matches = re.findall("^[a-zA-Z_0-9 ()]*$", token)
+    return len(matches) == 1
 
 # This class can be used to modify the behavior of string formatting
 #  of variable values
@@ -502,7 +506,7 @@ class StructMember:
     def __init__(self, schema, struct_name, xml_node):
         self.name = xml_node.getAttribute("name")
         self.struct_name = struct_name
-        if not is_valid_name(self.name):
+        if not is_valid_c_identifier(self.name):
             raise InvalidNameError(
                 "Member name '{}' of struct '{}' is invalid".format(
                     self.name,
@@ -566,7 +570,7 @@ class StructMember:
 class StructFormat(DataFormat):
     def __init__(self, schema, xml_node):
         self.name = xml_node.getAttribute("name")
-        if not is_valid_name(self.name):
+        if not is_valid_c_identifier(self.name):
             raise InvalidNameError("Struct name '{}' is invalid".format(
                 self.name))
         self.help = xml_node.getAttribute("help")
@@ -731,7 +735,7 @@ class StructFormat(DataFormat):
 class Knob:
     def __init__(self, schema, xml_node, namespace):
         self.name = xml_node.getAttribute("name")
-        if not is_valid_name(self.name):
+        if not is_valid_c_identifier(self.name):
             raise InvalidNameError(
                 "Knob name '{}' is invalid".format(self.name))
         self.help = xml_node.getAttribute("help")


### PR DESCRIPTION
…num spaces, starting with a digit and parentheses

# Preface

Please ensure you have read the [contribution docs](https://github.com/microsoft/mu/blob/master/CONTRIBUTING.md) prior
to submitting the pull request. In particular,
[pull request guidelines](https://github.com/microsoft/mu/blob/master/CONTRIBUTING.md#pull-request-best-practices).

## Description

Enums name values are used to display options in ConfigEditor.  To improve the user experience, enum names should not be limited to C identifiers (no spaces, no starting with a digit, etc), otherwise the usability of the options is impracted. 

These changes will enable the following items will be valid enum name entries:
```ini
      <Enum name="verify_enum_names">
        <Value name="1_Start_with_Integer" value="0" />
        <Value name="Contains Space" value="1" />
        <Value name="Has () and spaces In it" value="-1" />
    </Enum>
```


For each item, place an "x" in between `[` and `]` if true. Example: `[x]`.
_(you can also check items in the GitHub UI)_

- [x] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Tested using custom written xml files.

## Integration Instructions

n/a