### PR TITLE
The profile name variable should be a string array

### DIFF
--- a/SetupDataPkg/Include/Library/PlatformConfigDataLib.h
+++ b/SetupDataPkg/Include/Library/PlatformConfigDataLib.h
@@ -23,6 +23,6 @@ extern PROFILE    gProfileData[];
 // this does not count the generic profile, which is not
 // in gProfileData, but rather in gKnobData's defaults
 extern UINTN  gNumProfiles;
-extern CHAR8  *gProfileFlavorName;
+extern CHAR8  *gProfileFlavorName[];
 
 #endif // PLATFORM_CONFIG_DATA_LIB_H_

--- a/SetupDataPkg/Include/Library/PlatformConfigDataLib.h
+++ b/SetupDataPkg/Include/Library/PlatformConfigDataLib.h
@@ -23,6 +23,6 @@ extern PROFILE    gProfileData[];
 // this does not count the generic profile, which is not
 // in gProfileData, but rather in gKnobData's defaults
 extern UINTN  gNumProfiles;
-extern CHAR8  *gProfileFlavorName[];
+extern CHAR8  *gProfileFlavorNames[];
 
 #endif // PLATFORM_CONFIG_DATA_LIB_H_

--- a/SetupDataPkg/Library/PlatformConfigDataLibNull/PlatformConfigDataLibNull.c
+++ b/SetupDataPkg/Library/PlatformConfigDataLibNull/PlatformConfigDataLibNull.c
@@ -10,12 +10,12 @@
 #include <Uefi.h>
 #include <ConfigStdStructDefs.h>
 
-KNOB_DATA  gKnobData[0] = NULL;
+KNOB_DATA  gKnobData[1] = { 0 };
 
 UINTN  gNumKnobs = 0;
 
-PROFILE  gProfileData[0] = NULL;
-
-CHAR8  *gProfileFlavorNames[0] = NULL;
+PROFILE  gProfileData[1] = { 0 };
 
 UINTN  gNumProfiles = 0;
+
+CHAR8  *gProfileFlavorNames[1] = { NULL };

--- a/SetupDataPkg/Library/PlatformConfigDataLibNull/PlatformConfigDataLibNull.c
+++ b/SetupDataPkg/Library/PlatformConfigDataLibNull/PlatformConfigDataLibNull.c
@@ -10,12 +10,12 @@
 #include <Uefi.h>
 #include <ConfigStdStructDefs.h>
 
-KNOB_DATA  gKnobData = { 0 };
+KNOB_DATA  gKnobData[0];
 
 UINTN  gNumKnobs = 0;
 
-PROFILE  gProfileData = { 0 };
+PROFILE  gProfileData[0];
 
-CHAR8  *gProfileFlavorName = { 0 };
+CHAR8  *gProfileFlavorNames[0];
 
 UINTN  gNumProfiles = 0;

--- a/SetupDataPkg/Library/PlatformConfigDataLibNull/PlatformConfigDataLibNull.c
+++ b/SetupDataPkg/Library/PlatformConfigDataLibNull/PlatformConfigDataLibNull.c
@@ -10,12 +10,12 @@
 #include <Uefi.h>
 #include <ConfigStdStructDefs.h>
 
-KNOB_DATA  gKnobData[0];
+KNOB_DATA  gKnobData[0] = NULL;
 
 UINTN  gNumKnobs = 0;
 
-PROFILE  gProfileData[0];
+PROFILE  gProfileData[0] = NULL;
 
-CHAR8  *gProfileFlavorNames[0];
+CHAR8  *gProfileFlavorNames[0] = NULL;
 
 UINTN  gNumProfiles = 0;

--- a/SetupDataPkg/Tools/KnobService.py
+++ b/SetupDataPkg/Tools/KnobService.py
@@ -1122,7 +1122,7 @@ def generate_profiles(schema, profile_header_path, profile_paths, efi_type, prof
 
             out.write(get_line_ending(efi_type))
             out.write(get_type_string("char*", efi_type) + " g{}[PROFILE_COUNT]".format(
-                naming_convention_filter("_profile_flavor_name", False, efi_type)) + " = {"
+                naming_convention_filter("_profile_flavor_names", False, efi_type)) + " = {"
             )
             out.write(get_line_ending(efi_type))
             for profile_name in names_list:


### PR DESCRIPTION
## Description

This change fixes a bug from previous autogen contract data library, where the profile name field should actually be an array of `CHAR8*`.

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

This was tested with consumer build pipeline on proprietary platforms.

## Integration Instructions

N/A