### PR TITLE
Move ConfigKnobShimMmLib to MM_STANDALONE module type

### DIFF
--- a/SetupDataPkg/Library/ConfigKnobShimLib/ConfigKnobShimMmLib/ConfigKnobShimMmLib.inf
+++ b/SetupDataPkg/Library/ConfigKnobShimLib/ConfigKnobShimMmLib/ConfigKnobShimMmLib.inf
@@ -11,7 +11,7 @@
   BASE_NAME                 = ConfigKnobShimMmLib
   FILE_GUID                 = 675EE92E-8771-413A-8BBE-B87152B910E2
   VERSION_STRING            = 1.0
-  MODULE_TYPE               = BASE
+  MODULE_TYPE               = MM_STANDALONE
   LIBRARY_CLASS             = ConfigKnobShimLib | MM_STANDALONE DXE_SMM_DRIVER
   PI_SPECIFICATION_VERSION  = 0x00010032
 


### PR DESCRIPTION
# Preface

Please ensure you have read the [contribution docs](https://github.com/microsoft/mu/blob/master/CONTRIBUTING.md) prior
to submitting the pull request. In particular,
[pull request guidelines](https://github.com/microsoft/mu/blob/master/CONTRIBUTING.md#pull-request-best-practices).

## Description

ConfigKnobShimMmLib is not a BASE lib and instead should be listed as MM_STANDALONE to reflect the primary library class it is.

For each item, place an "x" in between `[` and `]` if true. Example: `[x]`.
_(you can also check items in the GitHub UI)_

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

N/A.

## Integration Instructions

N/A.
