### PR TITLE
UpdateConfigHdr.py: Resolve mws deprecation

### DIFF
--- a/SetupDataPkg/Plugins/UpdateConfigHdr/UpdateConfigHdr.py
+++ b/SetupDataPkg/Plugins/UpdateConfigHdr/UpdateConfigHdr.py
@@ -19,7 +19,7 @@ class UpdateConfigHdr(IUefiBuildPlugin):
     # Consumes build environment variables: "CONF_AUTOGEN_INCLUDE_PATH", "MU_SCHEMA_DIR",
     # "MU_SCHEMA_FILE_NAME", "CONF_PROFILE_PATHS" and "CONF_PROFILE_NAMES"
     def do_pre_build(self, thebuilder):
-        default_generated_path = thebuilder.mws.join(thebuilder.ws, "SetupDataPkg", "Test", "Include")
+        default_generated_path = thebuilder.edk2path.GetAbsolutePathOnThisSystemFromEdk2RelativePath("SetupDataPkg", "Test", "Include")
 
         final_dir = thebuilder.env.GetValue("CONF_AUTOGEN_INCLUDE_PATH", default_generated_path)
 
@@ -30,7 +30,7 @@ class UpdateConfigHdr(IUefiBuildPlugin):
             os.makedirs(final_dir)
 
         # Add generate routine here
-        cmd = thebuilder.mws.join(thebuilder.ws, "SetupDataPkg", "Tools", "KnobService.py")
+        cmd = thebuilder.edk2path.GetAbsolutePathOnThisSystemFromEdk2RelativePath("SetupDataPkg", "Tools", "KnobService.py")
 
         # MU_SCHEMA_DIR and MU_SCHEMA_FILE_NAME should be set by individual platforms
         # When running the CI, the configdata_ci scope will define MU_SCHEMA_DIR to the path of the
@@ -42,7 +42,7 @@ class UpdateConfigHdr(IUefiBuildPlugin):
 
         schema_file_name = thebuilder.env.GetValue("MU_SCHEMA_FILE_NAME", "testschema.xml")
 
-        schema_file = thebuilder.mws.join(schema_dir, schema_file_name)
+        schema_file = thebuilder.edk2path.GetAbsolutePathOnThisSystemFromEdk2RelativePath(schema_dir, schema_file_name)
 
         if not os.path.isfile(schema_file):
             logging.error(f"XML schema file \"{schema_file}\" specified is not found!!!")

--- a/SetupDataPkg/Plugins/UpdateConfigHdr/UpdateConfigHdr.py
+++ b/SetupDataPkg/Plugins/UpdateConfigHdr/UpdateConfigHdr.py
@@ -19,7 +19,9 @@ class UpdateConfigHdr(IUefiBuildPlugin):
     # Consumes build environment variables: "CONF_AUTOGEN_INCLUDE_PATH", "MU_SCHEMA_DIR",
     # "MU_SCHEMA_FILE_NAME", "CONF_PROFILE_PATHS" and "CONF_PROFILE_NAMES"
     def do_pre_build(self, thebuilder):
-        default_generated_path = thebuilder.edk2path.GetAbsolutePathOnThisSystemFromEdk2RelativePath("SetupDataPkg", "Test", "Include")
+        default_generated_path = thebuilder.edk2path.GetAbsolutePathOnThisSystemFromEdk2RelativePath(
+            "SetupDataPkg", "Test", "Include"
+        )
 
         final_dir = thebuilder.env.GetValue("CONF_AUTOGEN_INCLUDE_PATH", default_generated_path)
 
@@ -30,7 +32,9 @@ class UpdateConfigHdr(IUefiBuildPlugin):
             os.makedirs(final_dir)
 
         # Add generate routine here
-        cmd = thebuilder.edk2path.GetAbsolutePathOnThisSystemFromEdk2RelativePath("SetupDataPkg", "Tools", "KnobService.py")
+        cmd = thebuilder.edk2path.GetAbsolutePathOnThisSystemFromEdk2RelativePath(
+            "SetupDataPkg", "Tools", "KnobService.py"
+        )
 
         # MU_SCHEMA_DIR and MU_SCHEMA_FILE_NAME should be set by individual platforms
         # When running the CI, the configdata_ci scope will define MU_SCHEMA_DIR to the path of the


### PR DESCRIPTION
## Description

Replaces calls to `thebuilder.mws.join` to
`thebuilder.edk2path.GetAbsolutePathOnThisSystemFromEdk2RelativePath`.

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [x] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

QemuSbsaPkg built successfully.

## Integration Instructions

edk2-pytool-library must be v0.16.1 or greater
edk2-pytool-extensions must be v0.24.0 or greater
