### PR TITLE
Updated auto-gen script to accept cache for policy values

### DIFF
--- a/SetupDataPkg/Docs/PlatformIntegration/PlatformIntegrationSteps.md
+++ b/SetupDataPkg/Docs/PlatformIntegration/PlatformIntegrationSteps.md
@@ -140,6 +140,17 @@ are available for the code using the getters. In our mu_tiano_platforms example,
 Mapper is compiled with several C files that only include the client header, as the service header is only needed once
 per module to query the config knobs out of the config policy.
 
+The getter functions are implemented in the service header file. The traditional way to fetch a knob value will be to call
+the getter function with the knob name by supplying the pointer to hold such knob
+(i.e. `ConfigGetKnob1 (&Knob)`).
+
+Alternatively, getter functions can also be called with a knob name and a size-specified buffer. In this case, the getter
+function will inspect the cache buffer and try to populate the content if it is uninitialized. The caller should keep note
+of the intialized buffer for subsquent calls in the same module for optimal performance. The caller should also be aware
+that the buffer size should be large enough (`CACHED_POLICY_SIZE + CACHED_POLICY_HEADER_SIZE`) to hold the knob value.
+The usage of this alternative could work around the limitation of the traditional way that the relies on global variables
+when the modules are XIP (execute in place).
+
 The Silicon Policy Consumers do not need to include any of the above headers and will instead fetch their configuration
 directly from silicon policy.
 

--- a/SetupDataPkg/Tools/KnobService.py
+++ b/SetupDataPkg/Tools/KnobService.py
@@ -185,7 +185,9 @@ def write_uefi_getter_implementations(efi_type, out, schema):
             out.write("// {}".format(knob.help) + get_line_ending(efi_type))
 
         # Implement the cached getter function
-        out.write("// Get the current value of the {} knob from supplied cache".format(knob.name) + get_line_ending(efi_type))
+        out.write("// Get the current value of the {} knob from supplied cache".format(
+            knob.name
+        ) + get_line_ending(efi_type))
         out.write("EFI_STATUS {}{}FromCache (".format(
             naming_convention_filter("config_get_", False, efi_type),
             knob.name
@@ -271,7 +273,8 @@ def write_uefi_getter_implementations(efi_type, out, schema):
         ) + get_line_ending(efi_type))
         out.write(get_spacing_string(efi_type) + ")" + get_line_ending(efi_type))
         out.write("{" + get_line_ending(efi_type))
-        out.write(get_spacing_string(efi_type) + "return {}{}FromCache (Knob, CachedPolicy, sizeof (CachedPolicy));".format(
+        out.write(get_spacing_string(efi_type))
+        out.write("return {}{}FromCache (Knob, CachedPolicy, sizeof (CachedPolicy));".format(
             naming_convention_filter("config_get_", False, efi_type),
             knob.name
         ) + get_line_ending(efi_type))
@@ -966,8 +969,8 @@ def generate_getter_implementation(schema, header_path, efi_type):
         out.write("EFI_STATUS" + get_line_ending(efi_type))
         out.write(naming_convention_filter("init_config_policy_cache (", False, efi_type))
         out.write(get_line_ending(efi_type))
-        out.write(get_spacing_string(efi_type) + get_type_string("UINT8   *Cache,", efi_type) + get_line_ending(efi_type))
-        out.write(get_spacing_string(efi_type) + get_type_string("UINT16  CacheSize", efi_type))
+        out.write(get_spacing_string(efi_type) + "UINT8   *Cache," + get_line_ending(efi_type))
+        out.write(get_spacing_string(efi_type) + "UINT16  CacheSize")
         out.write(get_line_ending(efi_type) + ")" + get_line_ending(efi_type) + "{")
         out.write(get_line_ending(efi_type))
         out.write(get_spacing_string(efi_type))

--- a/SetupDataPkg/Tools/KnobService.py
+++ b/SetupDataPkg/Tools/KnobService.py
@@ -224,7 +224,8 @@ def write_uefi_getter_implementations(efi_type, out, schema):
         out.write(get_line_ending(efi_type))
 
         out.write(get_spacing_string(efi_type))
-        out.write("if (((CACHED_POLICY_HEADER*)Cache)->Signature != CACHED_POLICY_SINGATURE) {" + get_line_ending(efi_type))
+        out.write("if (((CACHED_POLICY_HEADER *)Cache)->Signature != CACHED_POLICY_SIGNATURE) {")
+        out.write(get_line_ending(efi_type))
         out.write(get_spacing_string(efi_type, num=2))
         out.write("Status = InitConfigPolicyCache (Cache, CacheSize);" + get_line_ending(efi_type))
         out.write(get_spacing_string(efi_type, num=2))
@@ -952,7 +953,7 @@ def generate_getter_implementation(schema, header_path, efi_type):
         out.write(get_line_ending(efi_type))
 
         policy_size = hex(get_conf_policy_size(schema))
-        out.write("#define CACHED_POLICY_SINGATURE    SIGNATURE_32 ('C', 'P', 'O', 'L')" + get_line_ending(efi_type))
+        out.write("#define CACHED_POLICY_SIGNATURE    SIGNATURE_32 ('C', 'P', 'O', 'L')" + get_line_ending(efi_type))
         out.write("#define CACHED_POLICY_HEADER_SIZE  sizeof (CACHED_POLICY_HEADER)" + get_line_ending(efi_type))
         out.write(get_line_ending(efi_type))
 
@@ -971,7 +972,8 @@ def generate_getter_implementation(schema, header_path, efi_type):
         out.write("#pragma pack ()" + get_line_ending(efi_type))
         out.write(get_line_ending(efi_type))
 
-        out.write("STATIC CHAR8 CachedPolicy[CACHED_POLICY_SIZE + CACHED_POLICY_HEADER_SIZE];" + get_line_ending(efi_type))
+        out.write("STATIC CHAR8 CachedPolicy[CACHED_POLICY_SIZE + CACHED_POLICY_HEADER_SIZE];")
+        out.write(get_line_ending(efi_type))
         out.write("STATIC BOOLEAN CachedPolicyInitialized = FALSE;")
         out.write(get_line_ending(efi_type))
         out.write(get_assert_style(efi_type, "(CACHED_POLICY_SIZE + CACHED_POLICY_HEADER_SIZE <= MAX_UINT16", '"Config too large!"'))
@@ -1007,7 +1009,7 @@ def generate_getter_implementation(schema, header_path, efi_type):
         out.write("}" + get_line_ending(efi_type))
         out.write(get_line_ending(efi_type))
         out.write(get_spacing_string(efi_type))
-        out.write("((CACHED_POLICY_HEADER*)Cache)->Signature = CACHED_POLICY_SINGATURE;" + get_line_ending(efi_type))
+        out.write("((CACHED_POLICY_HEADER*)Cache)->Signature = CACHED_POLICY_SIGNATURE;" + get_line_ending(efi_type))
         out.write(get_line_ending(efi_type))
         out.write(get_spacing_string(efi_type))
         out.write("return Status;" + get_line_ending(efi_type))

--- a/SetupDataPkg/Tools/KnobService.py
+++ b/SetupDataPkg/Tools/KnobService.py
@@ -976,7 +976,10 @@ def generate_getter_implementation(schema, header_path, efi_type):
         out.write(get_line_ending(efi_type))
         out.write("STATIC BOOLEAN CachedPolicyInitialized = FALSE;")
         out.write(get_line_ending(efi_type))
-        out.write(get_assert_style(efi_type, "(CACHED_POLICY_SIZE + CACHED_POLICY_HEADER_SIZE <= MAX_UINT16", '"Config too large!"'))
+        out.write(get_assert_style(
+            efi_type,
+            "(CACHED_POLICY_SIZE + CACHED_POLICY_HEADER_SIZE <= MAX_UINT16",
+            '"Config too large!"'))
         out.write(get_line_ending(efi_type))
         out.write(get_line_ending(efi_type))
 

--- a/SetupDataPkg/Tools/KnobService.py
+++ b/SetupDataPkg/Tools/KnobService.py
@@ -184,15 +184,18 @@ def write_uefi_getter_implementations(efi_type, out, schema):
         if knob.help != "":
             out.write("// {}".format(knob.help) + get_line_ending(efi_type))
 
-        out.write("// Get the current value of the {} knob".format(knob.name) + get_line_ending(efi_type))
-        out.write("EFI_STATUS {}{} (".format(
+        # Implement the cached getter function
+        out.write("// Get the current value of the {} knob from supplied cache".format(knob.name) + get_line_ending(efi_type))
+        out.write("EFI_STATUS {}{}FromCache (".format(
             naming_convention_filter("config_get_", False, efi_type),
             knob.name
         ) + get_line_ending(efi_type))
         out.write(get_spacing_string(efi_type))
-        out.write("{} *Knob".format(
+        out.write("{} *Knob,".format(
             get_type_string(knob.format.c_type, efi_type)
         ) + get_line_ending(efi_type))
+        out.write(get_spacing_string(efi_type) + "UINT8 *Cache," + get_line_ending(efi_type))
+        out.write(get_spacing_string(efi_type) + "UINT16 CacheSize" + get_line_ending(efi_type))
         out.write(get_spacing_string(efi_type) + ")" + get_line_ending(efi_type))
         out.write("{" + get_line_ending(efi_type))
         out.write(get_spacing_string(efi_type) + "EFI_STATUS Status;")
@@ -221,7 +224,7 @@ def write_uefi_getter_implementations(efi_type, out, schema):
         out.write(get_spacing_string(efi_type))
         out.write("if (!CachedPolicyInitialized) {" + get_line_ending(efi_type))
         out.write(get_spacing_string(efi_type, num=2))
-        out.write("Status = InitConfigPolicyCache ();" + get_line_ending(efi_type))
+        out.write("Status = InitConfigPolicyCache (Cache, CacheSize);" + get_line_ending(efi_type))
         out.write(get_spacing_string(efi_type, num=2))
         out.write("if (EFI_ERROR (Status)) {" + get_line_ending(efi_type))
         out.write(get_spacing_string(efi_type, num=3))
@@ -235,7 +238,7 @@ def write_uefi_getter_implementations(efi_type, out, schema):
         out.write(get_line_ending(efi_type))
 
         out.write(get_spacing_string(efi_type))
-        out.write("if (Offset + sizeof({}) > CachedPolicySize) {{".format(
+        out.write("if (Offset + sizeof({}) > CacheSize) {{".format(
             get_type_string(knob.format.c_type, efi_type)
         ) + get_line_ending(efi_type))
         out.write(get_spacing_string(efi_type, num=2))
@@ -247,12 +250,31 @@ def write_uefi_getter_implementations(efi_type, out, schema):
         out.write(get_line_ending(efi_type))
 
         out.write(get_spacing_string(efi_type))
-        out.write("CopyMem(Knob, CachedPolicy + Offset, sizeof ({}));".format(
+        out.write("CopyMem(Knob, Cache + Offset, sizeof ({}));".format(
             get_type_string(knob.format.c_type, efi_type)
         ) + get_line_ending(efi_type))
 
         out.write(get_spacing_string(efi_type))
         out.write("return EFI_SUCCESS;" + get_line_ending(efi_type))
+        out.write("}" + get_line_ending(efi_type))
+        out.write(get_line_ending(efi_type))
+
+        # Implement the normal getter function, from the global cache
+        out.write("// Get the current value of the {} knob from cache".format(knob.name) + get_line_ending(efi_type))
+        out.write("EFI_STATUS {}{} (".format(
+            naming_convention_filter("config_get_", False, efi_type),
+            knob.name
+        ) + get_line_ending(efi_type))
+        out.write(get_spacing_string(efi_type))
+        out.write("{} *Knob".format(
+            get_type_string(knob.format.c_type, efi_type)
+        ) + get_line_ending(efi_type))
+        out.write(get_spacing_string(efi_type) + ")" + get_line_ending(efi_type))
+        out.write("{" + get_line_ending(efi_type))
+        out.write(get_spacing_string(efi_type) + "return {}{}FromCache (Knob, CachedPolicy, sizeof (CachedPolicy));".format(
+            naming_convention_filter("config_get_", False, efi_type),
+            knob.name
+        ) + get_line_ending(efi_type))
         out.write("}" + get_line_ending(efi_type))
         out.write(get_line_ending(efi_type))
         pass
@@ -927,17 +949,15 @@ def generate_getter_implementation(schema, header_path, efi_type):
         out.write(get_line_ending(efi_type))
 
         policy_size = hex(get_conf_policy_size(schema))
-        out.write("STATIC CONST UINT16  CachedPolicySize = {};".format(
+        out.write("#define CACHED_POLICY_SIZE {}".format(
             policy_size
         ) + get_line_ending(efi_type))
-        out.write("STATIC CHAR8 CachedPolicy[{}];".format(
-            policy_size
-        ) + get_line_ending(efi_type))
+        out.write(get_line_ending(efi_type))
+
+        out.write("STATIC CHAR8 CachedPolicy[CACHED_POLICY_SIZE];" + get_line_ending(efi_type))
         out.write("STATIC BOOLEAN CachedPolicyInitialized = FALSE;")
         out.write(get_line_ending(efi_type))
-        out.write(get_assert_style(efi_type, "({} <= MAX_UINT16".format(
-            policy_size
-        ), '"Config too large!"'))
+        out.write(get_assert_style(efi_type, "(CACHED_POLICY_SIZE <= MAX_UINT16", '"Config too large!"'))
         out.write(get_line_ending(efi_type))
         out.write(get_line_ending(efi_type))
 
@@ -946,21 +966,22 @@ def generate_getter_implementation(schema, header_path, efi_type):
         out.write("EFI_STATUS" + get_line_ending(efi_type))
         out.write(naming_convention_filter("init_config_policy_cache (", False, efi_type))
         out.write(get_line_ending(efi_type))
-        out.write(get_spacing_string(efi_type) + get_type_string("void", efi_type))
+        out.write(get_spacing_string(efi_type) + get_type_string("UINT8   *Cache,", efi_type) + get_line_ending(efi_type))
+        out.write(get_spacing_string(efi_type) + get_type_string("UINT16  CacheSize", efi_type))
         out.write(get_line_ending(efi_type) + ")" + get_line_ending(efi_type) + "{")
         out.write(get_line_ending(efi_type))
         out.write(get_spacing_string(efi_type))
         out.write("EFI_STATUS Status;" + get_line_ending(efi_type))
         out.write(get_spacing_string(efi_type))
-        out.write("UINT16 ConfPolSize = CachedPolicySize;" + get_line_ending(efi_type))
+        out.write("UINT16 ConfPolSize = CacheSize;" + get_line_ending(efi_type))
         out.write(get_line_ending(efi_type))
 
         out.write(get_spacing_string(efi_type))
         out.write("Status = GetPolicy (")
         out.write("PcdGetPtr (PcdConfigurationPolicyGuid), NULL,")
-        out.write(" CachedPolicy, &ConfPolSize);" + get_line_ending(efi_type))
+        out.write(" Cache, &ConfPolSize);" + get_line_ending(efi_type))
         out.write(get_spacing_string(efi_type))
-        out.write("if ((EFI_ERROR (Status)) || (ConfPolSize != CachedPolicySize)) {" + get_line_ending(efi_type))
+        out.write("if ((EFI_ERROR (Status)) || (ConfPolSize != CACHED_POLICY_SIZE)) {" + get_line_ending(efi_type))
         out.write(get_spacing_string(efi_type, num=2) + "ASSERT (FALSE);")
         out.write(get_line_ending(efi_type))
         out.write(get_spacing_string(efi_type, num=2))


### PR DESCRIPTION
# Preface

Please ensure you have read the [contribution docs](https://github.com/microsoft/mu/blob/master/CONTRIBUTING.md) prior
to submitting the pull request. In particular,
[pull request guidelines](https://github.com/microsoft/mu/blob/master/CONTRIBUTING.md#pull-request-best-practices).

## Description

This change adds a set of getter functions that accepts a caller designated buffer for cached configuration policy. This will avoid the direct usage of updating global variable does not work (i.e. the module is XIP).

Fixes https://github.com/microsoft/mu_feature_config/issues/243.

For each item, place an "x" in between `[` and `]` if true. Example: `[x]`.
_(you can also check items in the GitHub UI)_

- [x] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [x] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

The auto-generated headers were built on QEMU Q35 and confirmed the GOP configuration knob works as expected.

## Integration Instructions

N/A for existing platforms. For platforms that require XIP usage, one should use `ConfigGet***FromCache` with user designated buffer, where the size of the buffer is specified in `CACHED_POLICY_SIZE`.
