### PR TITLE
Fixing for non-profile input case

### DIFF
--- a/SetupDataPkg/Tools/KnobService.py
+++ b/SetupDataPkg/Tools/KnobService.py
@@ -1329,6 +1329,8 @@ def main():
                                          % profileid)
                         return -1
                     formatted_profile_ids.append(hex(profileid))
+            else:
+                formatted_profile_ids = None
 
             generate_profiles(schema, profile_header_path, profile_paths, efi_type,
                               profile_names=known_args.profile_names, profile_ids=formatted_profile_ids)

--- a/SetupDataPkg/Tools/KnobService.py
+++ b/SetupDataPkg/Tools/KnobService.py
@@ -1173,10 +1173,12 @@ def generate_profiles(schema, profile_header_path, profile_paths, efi_type, prof
             out.write("};" + get_line_ending(efi_type))
             out.write(get_line_ending(efi_type))
             if profile_ids is not None:
-                ids_list = profile_ids
+                ids_iter = profile_ids
             else:
                 # If not specified, the indices will be the default profile ids
-                ids_list = [format(i, '02x') for i in range(len(profile_paths))]
+                ids_iter = range(len(profile_paths))
+
+            ids_list = ['0x' + format(i, '02x') for i in ids_iter]
 
             out.write(get_line_ending(efi_type))
             out.write(get_type_string("uint8_t", efi_type) + " g{}[PROFILE_COUNT]".format(
@@ -1328,7 +1330,7 @@ def main():
                         sys.stderr.write('Invalid profile id value 0x%x, should be 1-byte hexadecimal number. \n'
                                          % profileid)
                         return -1
-                    formatted_profile_ids.append(hex(profileid))
+                    formatted_profile_ids.append(profileid)
             else:
                 formatted_profile_ids = None
 


### PR DESCRIPTION
# Preface

Please ensure you have read the [contribution docs](https://github.com/microsoft/mu/blob/master/CONTRIBUTING.md) prior
to submitting the pull request. In particular,
[pull request guidelines](https://github.com/microsoft/mu/blob/master/CONTRIBUTING.md#pull-request-best-practices).

## Description

The previous change of adding profile ID into the autogenerated headers caused the build to break when there is no input for this parameter supplied: https://github.com/microsoft/mu_tiano_platforms/pull/723.

This change added the corresponding edge case handling and updated the autogenerated header formatting so that the output is self-consistent instead of strictly following the user input.

For each item, place an "x" in between `[` and `]` if true. Example: `[x]`.
_(you can also check items in the GitHub UI)_

- [x] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

This was tested on the top of QEMU Q35 platform and confirmed building and booting to shell.

## Integration Instructions

N/A
