### PR TITLE
Add the default in switch implementation to prevent gcc build error

### DIFF
--- a/SetupDataPkg/Tools/KnobService.py
+++ b/SetupDataPkg/Tools/KnobService.py
@@ -668,6 +668,8 @@ def generate_cached_implementation(schema, header_path, efi_type=False):
                     ) + get_line_ending(efi_type))
                     out.write(get_spacing_string(efi_type, 3) + "return {};".format(
                         get_value_string('true', efi_type)) + get_line_ending(efi_type))
+                out.write(get_spacing_string(efi_type, 2) + "default:" + get_line_ending(efi_type))
+                out.write(get_spacing_string(efi_type, 3) + "break;" + get_line_ending(efi_type))
                 out.write(get_spacing_string(efi_type) + "}" + get_line_ending(efi_type))
                 out.write(get_spacing_string(efi_type) + "return {};".format(
                     get_value_string('false', efi_type)


### PR DESCRIPTION
## Description

When the KnobService.py generate the ConfigDataGenerated.h, it generated the ValidateEnumValueXXXX function that has a switch implementation, but it missed the default: in the switch implementation that cause gcc build failed with [-Werror=switch] error.

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Verified the build that include ConfigDataGenerated.h by gcc compile

## Integration Instructions

N/A
