### PR TITLE
remove edk2-basetools

### DIFF
--- a/.pytool/CISettings.py
+++ b/.pytool/CISettings.py
@@ -16,13 +16,7 @@ from edk2toolext.invocables.edk2_pr_eval import PrEvalSettingsManager
 from edk2toollib.utility_functions import GetHostInfo
 from pathlib import Path
 
-try:
-    # May not be present until submodules are populated
-    root = Path(__file__).parent.parent.resolve()
-    sys.path.append(str(root / 'MU_BASECORE' / '.pytool' / 'Plugin' / 'CodeQL' / 'integration'))
-    import stuart_codeql as codeql_helpers
-except ImportError:
-    pass
+from edk2toolext import codeql as codeql_helpers
 
 
 class Settings(
@@ -37,7 +31,6 @@ class Settings(
         self.ActualTargets = []
         self.ActualArchitectures = []
         self.ActualToolChainTag = ""
-        self.UseBuiltInBaseTools = None
         self.ActualScopes = None
 
     # ####################################################################################### #
@@ -45,36 +38,12 @@ class Settings(
     # ####################################################################################### #
 
     def AddCommandLineOptions(self, parserObj):
-        group = parserObj.add_mutually_exclusive_group()
-        group.add_argument(
-            "-force_piptools",
-            "--fpt",
-            dest="force_piptools",
-            action="store_true",
-            default=False,
-            help="Force the system to use pip tools",
-        )
-        group.add_argument(
-            "-no_piptools",
-            "--npt",
-            dest="no_piptools",
-            action="store_true",
-            default=False,
-            help="Force the system to not use pip tools",
-        )
-
         try:
             codeql_helpers.add_command_line_option(parserObj)
         except NameError:
             pass
 
     def RetrieveCommandLineOptions(self, args):
-        super().RetrieveCommandLineOptions(args)
-        if args.force_piptools:
-            self.UseBuiltInBaseTools = True
-        if args.no_piptools:
-            self.UseBuiltInBaseTools = False
-
         try:
             self.codeql = codeql_helpers.is_codeql_enabled_on_command_line(args)
         except NameError:
@@ -165,23 +134,6 @@ class Settings(
             )
 
             is_linux = GetHostInfo().os.upper() == "LINUX"
-
-            if self.UseBuiltInBaseTools is None:
-                is_linux = GetHostInfo().os.upper() == "LINUX"
-                # try and import the pip module for basetools
-                try:
-                    import edk2basetools  # noqa: F401
-
-                    self.UseBuiltInBaseTools = True
-                except ImportError:
-                    self.UseBuiltInBaseTools = False
-                    pass
-
-            if self.UseBuiltInBaseTools is True:
-                scopes += ("pipbuild-unix",) if is_linux else ("pipbuild-win",)
-                logging.warning("Using Pip Tools based BaseTools")
-            else:
-                logging.warning("Falling back to using in-tree BaseTools")
 
             if is_linux and self.ActualToolChainTag.upper().startswith("GCC"):
                 if "AARCH64" in self.ActualArchitectures:

--- a/.pytool/CISettings.py
+++ b/.pytool/CISettings.py
@@ -6,7 +6,6 @@
 import glob
 import os
 import logging
-import sys
 from edk2toolext.environment import shell_environment
 from edk2toolext.invocables.edk2_ci_build import CiBuildSettingsManager
 from edk2toolext.invocables.edk2_ci_setup import CiSetupSettingsManager
@@ -14,8 +13,6 @@ from edk2toolext.invocables.edk2_setup import SetupSettingsManager
 from edk2toolext.invocables.edk2_update import UpdateSettingsManager
 from edk2toolext.invocables.edk2_pr_eval import PrEvalSettingsManager
 from edk2toollib.utility_functions import GetHostInfo
-from pathlib import Path
-
 from edk2toolext import codeql as codeql_helpers
 
 

--- a/pip-requirements.txt
+++ b/pip-requirements.txt
@@ -14,7 +14,6 @@
 
 edk2-pytool-library==0.21.2
 edk2-pytool-extensions==0.27.2
-edk2-basetools==0.1.49
 antlr4-python3-runtime==4.13.1
 xmlschema==3.0.1
 regex==2023.12.25


### PR DESCRIPTION
## Description

Removes edk2-basetools from pip-requirements.txt and any usage of it in the CISettings.py. The is done as there are changes in the build tools python source code that are available locally in BaseTools (as is managed by Project Mu) that is not available in edk2-basetools.

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Verified the build system continues to use the local python source

## Integration Instructions

N/A - only effects this repository's CI system.
