### PR TITLE
Add Linux Variable Writing Script

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -125,6 +125,9 @@
       "profilenames",
       "profileid",
       "profileids",
-      "prettyname"
+      "prettyname",
+      "efivars",
+      "efivarfs",
+      "chattr"
   ]
 }

--- a/SetupDataPkg/SetupDataPkg.ci.yaml
+++ b/SetupDataPkg/SetupDataPkg.ci.yaml
@@ -91,7 +91,10 @@
           "dmpstore",
           "mschange",
           "DDTHH",
-          "prettyname"
+          "prettyname",
+          "efivars",
+          "efivarfs",
+          "chattr"
         ],                           # words to extend to the dictionary for this package
         "IgnoreStandardPaths": [],   # Standard Plugin defined paths that should be ignore
         "AdditionalIncludePaths": [] # Additional paths to spell check (wildcards supported)

--- a/SetupDataPkg/Tools/SettingSupport/UefiVariablesSupportLib.py
+++ b/SetupDataPkg/Tools/SettingSupport/UefiVariablesSupportLib.py
@@ -10,7 +10,6 @@ from ctypes import (
     c_wchar_p,
     c_void_p,
     c_int,
-    c_char,
     create_string_buffer,
     WinError,
     pointer

--- a/SetupDataPkg/Tools/SettingSupport/UefiVariablesSupportLib.py
+++ b/SetupDataPkg/Tools/SettingSupport/UefiVariablesSupportLib.py
@@ -91,27 +91,6 @@ class UefiVariable(object):
             pass
 
     #
-    # Helper function to create buffer for var read/write
-    #
-    def CreateBuffer(self, init, size=None):
-        """CreateBuffer(aString) -> character array
-        CreateBuffer(anInteger) -> character array
-        CreateBuffer(aString, anInteger) -> character array
-        """
-        if isinstance(init, str):
-            if size is None:
-                size = len(init) + 1
-            buftype = c_char * size
-            buf = buftype()
-            buf.value = init
-            return buf
-        elif isinstance(init, int):
-            buftype = c_char * init
-            buf = buftype()
-            return buf
-        raise TypeError(init)
-
-    #
     # Function to get variable
     # return a tuple of error code and variable data as string
     #
@@ -135,8 +114,8 @@ class UefiVariable(object):
                 )
                 logging.error(WinError())
             if efi_var is None:
-                return (err, None, WinError(err))
-        return (err, efi_var[:length], WinError(err))
+                return (err, None)
+        return (err, efi_var[:length])
 
     #
     # Function to get all variable names
@@ -176,8 +155,8 @@ class UefiVariable(object):
             logging.error(
                 "EnumerateFirmwareEnvironmentVariable failed (GetLastError = 0x%x)" % status
             )
-            return (status, None, WinError(status))
-        return (status, efi_var_names, None)
+            return (status, None)
+        return (status, efi_var_names)
 
     #
     # Function to set variable
@@ -186,7 +165,6 @@ class UefiVariable(object):
     def SetUefiVar(self, name, guid, var=None, attrs=None):
         var_len = 0
         err = 0
-        error_string = None
         if var is None:
             var = bytes(0)
         else:
@@ -221,5 +199,4 @@ class UefiVariable(object):
                 "SetFirmwareEnvironmentVariable failed (GetLastError = 0x%x)" % err
             )
             logging.error(WinError())
-            error_string = WinError(err)
-        return (success, err, error_string)
+        return success

--- a/SetupDataPkg/Tools/SettingSupport/UefiVariablesSupportLinuxLib.py
+++ b/SetupDataPkg/Tools/SettingSupport/UefiVariablesSupportLinuxLib.py
@@ -7,7 +7,6 @@
 
 import os
 import uuid
-import sys
 import struct
 
 from ctypes import (
@@ -109,7 +108,6 @@ class UefiVariable(object):
     # return a tuple of boolean status, error_code, error_string (None if not error)
     #
     def SetUefiVar(self, name, guid, var=None, attrs=None):
-        var_len = 0
         success = 0  # Fail
 
         # There is a null terminator at the end of the name
@@ -120,8 +118,6 @@ class UefiVariable(object):
                 os.remove(path)
                 success = 1 # expect non-zero success
             return success
-        else:
-            var_len = len(var)
 
         if attrs is None:
             attrs = 0x7

--- a/SetupDataPkg/Tools/SettingSupport/UefiVariablesSupportLinuxLib.py
+++ b/SetupDataPkg/Tools/SettingSupport/UefiVariablesSupportLinuxLib.py
@@ -21,26 +21,6 @@ class UefiVariable(object):
 
     def __init__(self):
         pass
-    #
-    # Helper function to create buffer for var read/write
-    #
-    def CreateBuffer(self, init, size=None):
-        """CreateBuffer(aString) -> character array
-        CreateBuffer(anInteger) -> character array
-        CreateBuffer(aString, anInteger) -> character array
-        """
-        if isinstance(init, str):
-            if size is None:
-                size = len(init) + 1
-            buftype = c_char * size
-            buf = buftype()
-            buf.value = init
-            return buf
-        elif isinstance(init, int):
-            buftype = c_char * init
-            buf = buftype()
-            return buf
-        raise TypeError(init)
 
     #
     # Function to get variable

--- a/SetupDataPkg/Tools/SettingSupport/UefiVariablesSupportLinuxLib.py
+++ b/SetupDataPkg/Tools/SettingSupport/UefiVariablesSupportLinuxLib.py
@@ -2,8 +2,11 @@
 #
 # Python lib to support Reading and writing UEFI variables from Linux
 #
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
 # Copyright (c), Microsoft Corporation
 # SPDX-License-Identifier: BSD-2-Clause-Patent
+#
 
 import os
 import uuid
@@ -55,7 +58,7 @@ class UefiVariable(object):
         # success
         status = 0
 
-        # implementation borrowed from https://github.com/awslabs/python-uefivars/blob/main/pyuefivars/efivarfs.py
+        # implementation borrowed from https://github.com/awslabs/python-uefivars/blob/main/pyuefivars/efivarfs.py hash 47291b3
         path = '/sys/firmware/efi/efivars'
         if not os.path.exists(path):
             status = UefiVariable.ERROR_ENVVAR_NOT_FOUND

--- a/SetupDataPkg/Tools/SettingSupport/UefiVariablesSupportLinuxLib.py
+++ b/SetupDataPkg/Tools/SettingSupport/UefiVariablesSupportLinuxLib.py
@@ -2,12 +2,15 @@
 #
 # Python lib to support Reading and writing UEFI variables from Linux
 #
-# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-# SPDX-License-Identifier: MIT
 #
 # Copyright (c), Microsoft Corporation
-# SPDX-License-Identifier: MIT
+# SPDX-License-Identifier: BSD-2-Clause-Patent
 #
+# GetUefiAllVarNames is based on information from
+# https://github.com/awslabs/python-uefivars/blob/main/pyuefivars/efivarfs.py
+#
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT
 
 import os
 import uuid

--- a/SetupDataPkg/Tools/SettingSupport/UefiVariablesSupportLinuxLib.py
+++ b/SetupDataPkg/Tools/SettingSupport/UefiVariablesSupportLinuxLib.py
@@ -54,13 +54,13 @@ class UefiVariable(object):
 
         if not os.path.exists(path):
             err = UefiVariable.ERROR_ENVVAR_NOT_FOUND
-            return (err, None, None)
+            return (err, None)
 
         efi_var = create_string_buffer(EFI_VAR_MAX_BUFFER_SIZE)
         with open(path, 'rb') as fd:
             efi_var = fd.read()
 
-        return (err, efi_var, None)
+        return (err, efi_var)
 
     #
     # Function to get all variable names
@@ -80,7 +80,7 @@ class UefiVariable(object):
         path = '/sys/firmware/efi/efivars'
         if not os.path.exists(path):
             status = UefiVariable.ERROR_ENVVAR_NOT_FOUND
-            return (status, None, None)
+            return (status, None)
 
         vars = os.listdir(path)
 
@@ -106,18 +106,18 @@ class UefiVariable(object):
             name = name.encode('utf-16')
 
             # NextEntryOffset
-            efi_var_names[offset] = struct.pack('=I', sys.getsizeof(int) + sys.getsizeof(name) + sys.getsizeof(guid))
+            struct.pack_into('=I', efi_var_names, offset, sys.getsizeof(int) + sys.getsizeof(name) + sys.getsizeof(guid))
             offset += sys.getsizeof(int)
 
             # VendorGuid
-            efi_var_names[offset] = struct.packed('=s', guid.toString())
+            struct.pack_into('=s', efi_var_names, offset, guid)
             offset += sys.getsizeof(guid)
 
             # Name
-            efi_var_names[offset] = name
+            struct.pack_into('=s', efi_var_names, offset, name)
             offset += sys.getsizeof(name)
 
-        return (status, efi_var_names, None)
+        return (status, efi_var_names)
 
     #
     # Function to set variable

--- a/SetupDataPkg/Tools/SettingSupport/UefiVariablesSupportLinuxLib.py
+++ b/SetupDataPkg/Tools/SettingSupport/UefiVariablesSupportLinuxLib.py
@@ -18,6 +18,7 @@ from ctypes import (
 
 EFI_VAR_MAX_BUFFER_SIZE = 1024 * 1024
 
+
 class UefiVariable(object):
     ERROR_ENVVAR_NOT_FOUND = 0xcb
 
@@ -58,7 +59,7 @@ class UefiVariable(object):
         # success
         status = 0
 
-        # implementation borrowed from https://github.com/awslabs/python-uefivars/blob/main/pyuefivars/efivarfs.py hash 47291b3
+        # implementation borrowed from https://github.com/awslabs/python-uefivars/blob/main/pyuefivars/efivarfs.py
         path = '/sys/firmware/efi/efivars'
         if not os.path.exists(path):
             status = UefiVariable.ERROR_ENVVAR_NOT_FOUND
@@ -119,7 +120,7 @@ class UefiVariable(object):
             # we are deleting the variable
             if (os.path.exists(path)):
                 os.remove(path)
-                success = 1 # expect non-zero success
+                success = 1  # expect non-zero success
             return success
 
         if attrs is None:

--- a/SetupDataPkg/Tools/SettingSupport/UefiVariablesSupportLinuxLib.py
+++ b/SetupDataPkg/Tools/SettingSupport/UefiVariablesSupportLinuxLib.py
@@ -3,9 +3,10 @@
 # Python lib to support Reading and writing UEFI variables from Linux
 #
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT
 #
 # Copyright (c), Microsoft Corporation
-# SPDX-License-Identifier: BSD-2-Clause-Patent
+# SPDX-License-Identifier: MIT
 #
 
 import os

--- a/SetupDataPkg/Tools/SettingSupport/UefiVariablesSupportLinuxLib.py
+++ b/SetupDataPkg/Tools/SettingSupport/UefiVariablesSupportLinuxLib.py
@@ -1,0 +1,148 @@
+# @file
+#
+# Python lib to support Reading and writing UEFI variables from Linux
+#
+# Copyright (c), Microsoft Corporation
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+
+import os
+import uuid
+import sys
+import struct
+
+from ctypes import (
+    create_string_buffer
+)
+
+EFI_VAR_MAX_BUFFER_SIZE = 1024 * 1024
+
+class UefiVariable(object):
+    ERROR_ENVVAR_NOT_FOUND = 0xcb
+
+    def __init__(self):
+        pass
+    #
+    # Helper function to create buffer for var read/write
+    #
+    def CreateBuffer(self, init, size=None):
+        """CreateBuffer(aString) -> character array
+        CreateBuffer(anInteger) -> character array
+        CreateBuffer(aString, anInteger) -> character array
+        """
+        if isinstance(init, str):
+            if size is None:
+                size = len(init) + 1
+            buftype = c_char * size
+            buf = buftype()
+            buf.value = init
+            return buf
+        elif isinstance(init, int):
+            buftype = c_char * init
+            buf = buftype()
+            return buf
+        raise TypeError(init)
+
+    #
+    # Function to get variable
+    # return a tuple of error code and variable data as string
+    #
+    def GetUefiVar(self, name, guid):
+        # success
+        err = 0
+        # the variable name is VariableName-Guid
+        path = '/sys/firmware/efi/efivars/' + name + '-%s' % guid
+
+        if not os.path.exists(path):
+            err = UefiVariable.ERROR_ENVVAR_NOT_FOUND
+            return (err, None, None)
+
+        efi_var = create_string_buffer(EFI_VAR_MAX_BUFFER_SIZE)
+        with open(path, 'rb') as fd:
+            efi_var = fd.read()
+
+        return (err, efi_var, None)
+
+    #
+    # Function to get all variable names
+    # return a tuple of error code and variable names byte array formatted as:
+    #
+    # typedef struct _VARIABLE_NAME {
+    #   ULONG NextEntryOffset;
+    #   GUID VendorGuid;
+    #   WCHAR Name[ANYSIZE_ARRAY];
+    # } VARIABLE_NAME, *PVARIABLE_NAME;
+    #
+    def GetUefiAllVarNames(self):
+        # success
+        status = 0
+
+        # implementation borrowed from https://github.com/awslabs/python-uefivars/blob/main/pyuefivars/efivarfs.py
+        path = '/sys/firmware/efi/efivars'
+        if not os.path.exists(path):
+            status = UefiVariable.ERROR_ENVVAR_NOT_FOUND
+            return (status, None, None)
+
+        vars = os.listdir(path)
+
+        # get the total buffer length, converting to unicode
+        length = 0
+        offset = 0
+        for var in vars:
+            length += sys.getsizeof(int) + (sys.getsizeof(var.encode('utf-16')))
+
+        efi_var_names = create_string_buffer(length)
+
+        for var in vars:
+            # efivarfs stores vars as NAME-GUID
+            split_string = var.split('-')
+            try:
+                # GUID is last 5 elements of split_string
+                guid = uuid.UUID('-'.join(split_string[-5:])).bytes_le
+            except ValueError:
+                raise Exception(f'Could not parse "{var}"')
+
+            # the other part is the name
+            name = '-'.join(split_string[:-5])
+            name = name.encode('utf-16')
+
+            # NextEntryOffset
+            efi_var_names[offset] = struct.pack('=I', sys.getsizeof(int) + sys.getsizeof(name) + sys.getsizeof(guid))
+            offset += sys.getsizeof(int)
+
+            # VendorGuid
+            efi_var_names[offset] = struct.packed('=s', guid.toString())
+            offset += sys.getsizeof(guid)
+
+            # Name
+            efi_var_names[offset] = name
+            offset += sys.getsizeof(name)
+
+        return (status, efi_var_names, None)
+
+    #
+    # Function to set variable
+    # return a tuple of boolean status, error_code, error_string (None if not error)
+    #
+    def SetUefiVar(self, name, guid, var=None, attrs=None):
+        var_len = 0
+        success = 0  # Fail
+        path = '/sys/firmware/efi/efivars/' + name + '-' + str(guid)
+        if var is None:
+            # we are deleting the variable
+            if (os.path.exists(path)):
+                os.remove(path)
+                success = 1 # expect non-zero success
+            return success
+        else:
+            var_len = len(var)
+
+        if attrs is None:
+            attrs = 0x7
+
+        with open (path, 'wb') as fd:
+            # var data is attribute (UINT32) followed by data
+            packed = struct.pack('=I', attrs)
+            packed += var
+            fd.write(packed)
+
+        return 1

--- a/SetupDataPkg/Tools/WriteConfVarListToUefiVars.py
+++ b/SetupDataPkg/Tools/WriteConfVarListToUefiVars.py
@@ -12,7 +12,10 @@ import argparse
 import struct
 import uuid
 import ctypes
-from SettingSupport.UefiVariablesSupportLib import UefiVariable
+if os.name == 'nt':
+    from SettingSupport.UefiVariablesSupportLib import UefiVariable
+else:
+    from SettingSupport.UefiVariablesSupportLinuxLib import UefiVariable
 
 gEfiGlobalVariableGuid = "8BE4DF61-93CA-11D2-AA0D-00E098032B8C"
 

--- a/SetupDataPkg/Tools/WriteConfVarListToUefiVars.py
+++ b/SetupDataPkg/Tools/WriteConfVarListToUefiVars.py
@@ -93,7 +93,7 @@ def extract_single_var_from_file_and_write_nvram(var):
         logging.debug(f"Found Variable: {VarName} {Guid} {Attributes}")
 
         UefiVar = UefiVariable()
-        (rc, err, error_string) = UefiVar.SetUefiVar(
+        rc = UefiVar.SetUefiVar(
             VarName,
             Guid,
             Data,
@@ -136,9 +136,14 @@ if __name__ == "__main__":
     console.setLevel(logging.CRITICAL)
 
     # check the privilege level and report error
-    if not ctypes.windll.shell32.IsUserAnAdmin():
-        print("Administrator privilege required. Please launch from an Administrator privilege level.")
-        sys.exit(1)
+    if os.name == 'nt':
+        if not ctypes.windll.shell32.IsUserAnAdmin():
+            print("Administrator privilege required. Please launch from an Administrator privilege level.")
+            sys.exit(1)
+    else:
+        if os.geteuid() != 0:
+            print("Root permission required, please run script with sudo.")
+            sys.exit(1)
 
     # call main worker function
     retcode = main()


### PR DESCRIPTION
## Description

This adds a Python script to write UEFI variables to and from config bins from Linux. The current support is only for Windows.

For each item, place an "x" in between `[` and `]` if true. Example: `[x]`.
_(you can also check items in the GitHub UI)_

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Tested in Ubuntu 24.04 with the QemuQ35 virtual platform using mu_feature_config as well as on physical platforms using it.

## Integration Instructions

Run the same flows as for the Windows script, the scripts will automatically detect that this is run from Linux and choose the right script. It needs to be run as sudo.
