### PR TITLE
SetupDataPkg/ConfigKnobShimPeiLib: Revert ConfigKnobShimPeiLib change and fix unit test.

### DIFF
--- a/SetupDataPkg/Library/ConfigKnobShimLib/ConfigKnobShimPeiLib/ConfigKnobShimPeiLib.inf
+++ b/SetupDataPkg/Library/ConfigKnobShimLib/ConfigKnobShimPeiLib/ConfigKnobShimPeiLib.inf
@@ -23,7 +23,9 @@
 
 [Sources]
   ConfigKnobShimPeiLib.c
-
+  ../ConfigKnobShimLibCommon.c
+  ../ConfigKnobShimLibCommon.h
+  
 [Packages]
   MdePkg/MdePkg.dec
   SetupDataPkg/SetupDataPkg.dec

--- a/SetupDataPkg/Library/ConfigKnobShimLib/ConfigKnobShimPeiLib/GoogleTest/ConfigKnobShimPeiLibGoogleTest.inf
+++ b/SetupDataPkg/Library/ConfigKnobShimLib/ConfigKnobShimPeiLib/GoogleTest/ConfigKnobShimPeiLibGoogleTest.inf
@@ -20,7 +20,6 @@
 
 [Sources]
   ConfigKnobShimPeiLibGoogleTest.cpp
-  ../../ConfigKnobShimLibCommon.c
   MdePkg/Test/Mock/Library/GoogleTest/Ppi/MockReadOnlyVariable2.cpp
 
 [Packages]


### PR DESCRIPTION
## Description

Commit #369 erroneously removed the implementation for GetConfigKnobOverride from ConfigKnobShimPeiLib. Adding back the implementation to PEI and fixing the unit test to correctly work, in the same fashion as Dxe/MM versions.

For each item, place an "x" in between `[` and `]` if true. Example: `[x]`.
_(you can also check items in the GitHub UI)_

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested
Mu Oem sample was failing with an unresolved external GetConfigKnobOverride for X64 PEI. 
After making this change, the unresolved external was resolved. 

## Integration Instructions
N/A