### PR TITLE
UpdateConfigHdr: Gracefully exit when filepath is `None`

### DIFF
--- a/SetupDataPkg/Plugins/UpdateConfigHdr/UpdateConfigHdr.py
+++ b/SetupDataPkg/Plugins/UpdateConfigHdr/UpdateConfigHdr.py
@@ -56,8 +56,8 @@ class UpdateConfigHdr(IUefiBuildPlugin):
             file = thebuilder.edk2path.GetAbsolutePathOnThisSystemFromEdk2RelativePath(schema_dir, name)
             schema_files.append(file)
 
-            if not os.path.isfile(file):
-                logging.error(f"XML schema file \"{file}\" specified is not found!!!")
+            if file is None:
+                logging.error(f"XML schema file \"{schema_dir}/{name}\" specified is not found!!!")
                 return -1
 
         # this is a semicolon delimited list of space separated lists of paths to CSV files describing the profiles for


### PR DESCRIPTION
## Description

`GetAbsolutePathOnThisSystemFromEdk2RelativePath` will log an error message and return `None` if absolute path could not be determined. Due to this, file should be checked against `None`, not `os.path.isfile`.

You can see that in the [GetAbsolutePathOnThisSystemFromEdk2RelativePath](https://github.com/tianocore/edk2-pytool-library/blob/b4746ac9386de524a67c2d367bba1cba45d41b61/edk2toollib/uefi/edk2/path_utilities.py#L211) that we return a str if the absolute path is found, else `None`.

Currently, when a path is not found, you get this exception and trace:
<img width="1025" alt="image" src="https://github.com/microsoft/mu_feature_config/assets/24388509/d3b73c75-333b-4a8c-b045-ac90f71352ad">


- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

N/A

## Integration Instructions

N/A
