### PR TITLE
SetupDataPkg/ConfApp: Fix incorrect type used in a GUID print

### DIFF
--- a/SetupDataPkg/ConfApp/SetupConf.c
+++ b/SetupDataPkg/ConfApp/SetupConf.c
@@ -732,20 +732,20 @@ CreateXmlStringFromCurrentSettings (
         DataSize = 0;
         Status   = mPolicyProtocol->GetPolicy (&TargetGuids[i], NULL, Data, (UINT16 *)&DataSize);
         if (Status != EFI_BUFFER_TOO_SMALL) {
-          DEBUG ((DEBUG_ERROR, "%a Failed to get configuration policy size %g - %r\n", __FUNCTION__, TargetGuids[i], Status));
+          DEBUG ((DEBUG_ERROR, "%a Failed to get configuration policy size %g - %r\n", __FUNCTION__, &TargetGuids[i], Status));
           ASSERT (FALSE);
           continue;
         }
 
         Data = AllocatePool (DataSize);
         if (Data == NULL) {
-          DEBUG ((DEBUG_ERROR, "%a Unable to allocate pool for configuration policy %g\n", __FUNCTION__, TargetGuids[i]));
+          DEBUG ((DEBUG_ERROR, "%a Unable to allocate pool for configuration policy %g\n", __FUNCTION__, &TargetGuids[i]));
           break;
         }
 
         Status = mPolicyProtocol->GetPolicy (&TargetGuids[i], NULL, Data, (UINT16 *)&DataSize);
         if (EFI_ERROR (Status)) {
-          DEBUG ((DEBUG_ERROR, "%a Failed to get configuration policy %g - %r\n", __FUNCTION__, TargetGuids[i], Status));
+          DEBUG ((DEBUG_ERROR, "%a Failed to get configuration policy %g - %r\n", __FUNCTION__, &TargetGuids[i], Status));
           ASSERT (FALSE);
           FreePool (Data);
           Data = NULL;


### PR DESCRIPTION
## Description

The DEBUG message will throughout expectations, due to pass wrong type variable.  
The %g parameter need to pass the GUID pointer not the variable itself. so chang TargetGuids[i] to &TargetGuids[i]

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Test have been run on an Arm based simulator. No exception throughout after adding the &. 

## Integration Instructions

N/A