### PR TITLE
Remove xml_file args from WriteConfVarListToUefiVars.py

### DIFF
--- a/SetupDataPkg/Tools/WriteConfVarListToUefiVars.py
+++ b/SetupDataPkg/Tools/WriteConfVarListToUefiVars.py
@@ -30,16 +30,6 @@ def option_parser():
         help="""Specify the input setting file""",
     )
 
-    parser.add_argument(
-        "-x",
-        "--xml",
-        dest="xml_file",
-        required=True,
-        type=str,
-        default='""',
-        help="""Specify the xml file""",
-    )
-
     arguments = parser.parse_args()
 
     if not os.path.isfile(arguments.setting_file):


### PR DESCRIPTION
## Description

There is an unnecessary argument -x in the `WriteConfVarListToUefiVars.py` script in PR #413

For details on how to complete these options and their meaning refer to [CONTRIBUTING.md](https://github.com/microsoft/mu/blob/HEAD/CONTRIBUTING.md).

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

python WriteConfVarListToUefiVars.py -l test.vl and it doesn't require -x arg
## Integration Instructions

N/A