### PR TITLE
Add missing gSchemaXmlHash in PlatformConfigDataLibNull.c

### DIFF
--- a/SetupDataPkg/Library/PlatformConfigDataLibNull/PlatformConfigDataLibNull.c
+++ b/SetupDataPkg/Library/PlatformConfigDataLibNull/PlatformConfigDataLibNull.c
@@ -21,3 +21,5 @@ UINTN  gNumProfiles = 0;
 CHAR8  *gProfileFlavorNames[1] = { NULL };
 
 UINT8  gProfileFlavorIds[1] = { 0 };
+
+CHAR8  *gSchemaXmlHash = NULL;


### PR DESCRIPTION
## Description

Add missing gSchemaXmlHash in PlatformConfigDataLibNull.c for stuart_ci_build test

For details on how to complete these options and their meaning refer to [CONTRIBUTING.md](https://github.com/microsoft/mu/blob/HEAD/CONTRIBUTING.md).

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

 stuart_ci_build pipeline test pass

## Integration Instructions

