### PR TITLE
ConfigEditor: Large Enum Value Support (#438)

### DIFF
--- a/SetupDataPkg/Tools/VariableList.py
+++ b/SetupDataPkg/Tools/VariableList.py
@@ -384,13 +384,13 @@ class EnumFormat(DataFormat):
         return str(object_representation)
 
     def object_to_binary(self, object_representation):
-        return struct.pack("<i", object_representation)
+        return struct.pack("<I", object_representation)
 
     def binary_to_object(self, binary_representation):
-        return struct.unpack("<i", binary_representation)[0]
+        return struct.unpack("<I", binary_representation)[0]
 
     def size_in_bytes(self):
-        return struct.calcsize("<i")
+        return struct.calcsize("<I")
 
     def check_bounds(self, value, min, max):
         if min is not None:


### PR DESCRIPTION
## Description

Use <I instead of <i for EnumFormat in order to support UINT32 enum

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Execute ConfigEditor.py and loads a config xml file with UINT32 enum values.
A sample xml has been attached in https://github.com/microsoft/mu_feature_config/issues/438

## Integration Instructions

N/A