### PR TITLE
[ConfigEditor] Update config data before leaving the page

### DIFF
--- a/SetupDataPkg/Tools/ConfigEditor.py
+++ b/SetupDataPkg/Tools/ConfigEditor.py
@@ -1007,6 +1007,7 @@ class application(tkinter.Frame):
     def previous_page(self, page_id):
         if self.current_page > 0:
             self.current_page -= 1
+            self.update_config_data_on_page()
             self.build_config_data_page(page_id)
 
     # Goes to a specific page if the input is valid
@@ -1015,6 +1016,7 @@ class application(tkinter.Frame):
             page_index = int(page_num) - 1  # Convert to 0-based
             if page_index >= 0 and page_index < self.total_pages:
                 self.current_page = page_index
+                self.update_config_data_on_page()
                 self.build_config_data_page(page_id)
             else:
                 self.output_current_status('[go_to_page] Skip invalid page number: %s' % page_num)
@@ -1025,6 +1027,7 @@ class application(tkinter.Frame):
     def next_page(self, page_id):
         if self.current_page < self.total_pages - 1:
             self.current_page += 1
+            self.update_config_data_on_page()
             self.build_config_data_page(page_id)
 
     def load_config_data(self, file_name):


### PR DESCRIPTION
## Description

If users modify some values in combo boxes without clicking the left tree and then click the pagination control buttons, the modified values may not take effect. We may need to ensure that the changes take effect in the config data before leaving the page, just like many other buttons do.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

1. Execute ConfigEditor.py.
2. Load a Config XML containing a struct with more than 500 members, so the pagination control buttons appear on the right grid.
3. Modify combo box values and dropdown list selections.
4. Navigate back and forth using the pagination control to verify whether the modified values persist.

## Integration Instructions

N/A
