### PR TITLE
Add MODCONFIG/DELVAR cmd line interface to modify config variables

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -170,6 +170,7 @@
       "ENABLEDDISABLE",
       "vfrxml",
       "onvalue",
-      "offvalue"
+      "offvalue",
+      "DELVAR"
   ]
 }


### PR DESCRIPTION
## Description
The current config editor tool requires UI interface to modify config variables.
Although, we can use multiple GenNCCfgData.py cmd lines/config.xml tweak to achieve same functions, but it's not convenient to use 
This PR adds a ModConfig.py cmd line interface to modify config variables.

Usage:
$ python GenNCCfgData.py MODCONFIG --xml_file config.xml --var knob1 --var knob2 --val knob_val1 --val knob_val2 [--output_file out.vl]

modify <array>int config var
$ python GenNCCfgData.py MODCONFIG --xml_file config.xml --var "NetworkBootOrder" --val "[1,3,2,4]"

Delete all config var
$ python GenNCCfgData.py DELVAR --xml_file config.xml


- [ ] Impacts functionality?
- [ ] Impacts security?
- [x] Breaking change?
- [x] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Tested on SUT and make sure the config variables can be modified or deleted
Old function GENBIN and GENCSV are also working like before.

## Integration Instructions

N/A