### PR TITLE
Include PcdLib and BaseMemoryLib since in the autogen header since it invokes PcdGetPtr() and CopyMem()

### DIFF
--- a/SetupDataPkg/Tools/KnobService.py
+++ b/SetupDataPkg/Tools/KnobService.py
@@ -995,6 +995,8 @@ def generate_getter_implementation(schema, header_path, efi_type):
     with open(header_path, 'w', newline='') as out:
         out.write(get_spdx_header(header_path, efi_type))
         out.write(get_include_once_style(header_path, uefi=efi_type, header=True))
+        out.write("#include <Library/PcdLib.h>" + get_line_ending(efi_type))
+        out.write("#include <Library/BaseMemoryLib.h>" + get_line_ending(efi_type))
         out.write("// The config public header must be included prior to this file" + get_line_ending(efi_type))
         out.write("// Generated Header" + get_line_ending(efi_type))
         out.write("//  Script: {}".format(sys.argv[0]) + get_line_ending(efi_type))


### PR DESCRIPTION
## Description

In the autogen service header (e.g. ConfigServiceGenerated.h), PcdGetPtr() and CopyMem() are invoked, but it does not include corresponding PcdLib.h and BaseMemoryLib.h.

Currently when we include ConfigServiceGenerated.h in another .c file, we usually get build errors and realize that we also need to include PcdLib.h and BaseMemoryLib.h.

It would be better if we could have the right inclusion in the autogen header, as well as ConfigClientGenerated.h includes Uefi.h.

For details on how to complete these options and their meaning refer to [CONTRIBUTING.md](https://github.com/microsoft/mu/blob/HEAD/CONTRIBUTING.md).

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- Built and Booted System UEFI with .c files which include ConfigServiceGenerated.h.

- Built and Booted System UEFI with .c filfes which include ConfigServiceGenerated.h and also include PcdLib.h and BaseMemoryLib.h as before.

- Compared and verified the AutoGen headers before and after this code diff
Before:
```
#ifndef CONFIGSERVICEGENERATED_H
#define CONFIGSERVICEGENERATED_H
// The config public header must be included prior to this file
// Generated Header
```

After:
```
#ifndef CONFIGSERVICEGENERATED_H
#define CONFIGSERVICEGENERATED_H
#include <Library/PcdLib.h>
#include <Library/BaseMemoryLib.h>
// The config public header must be included prior to this file
// Generated Header
```

## Integration Instructions

N/A
