### PR TITLE
SetupDataPkg: ConfApp fix size comparison mismatch.

### DIFF
--- a/SetupDataPkg/ConfApp/ConfApp.c
+++ b/SetupDataPkg/ConfApp/ConfApp.c
@@ -291,7 +291,7 @@ CheckSupportedOptions (
       continue;
     }
 
-    if (KeyOptions[Index].EndState == MAX_UINTN) {
+    if (KeyOptions[Index].EndState == MAX_UINT32) {
       continue;
     }
 


### PR DESCRIPTION
## Description

When compiling with clangdwarf, a build error is throw because a UINT32 variable is being compared against a MAX_UINTN.

This works fine for IA32 builds, but fails for x64.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested
Compiling with clangdwarf, encountered an error. After fix, compilation is successful.

## Integration Instructions
No integration necessary.