### PR TITLE
Update to 202608 branches

### DIFF
--- a/.azurepipelines/MuDevOpsWrapper.yml
+++ b/.azurepipelines/MuDevOpsWrapper.yml
@@ -87,7 +87,7 @@ parameters:
 jobs:
 - template: Jobs/PrGate.yml@mu_devops
   parameters:
-    linux_container_image: ghcr.io/microsoft/mu_devops/ubuntu-24-build:0e384ee
+    linux_container_image: ghcr.io/microsoft/mu_devops/ubuntu-24-build:76935a3
     ${{ if eq(parameters.rust_build, true) }}:
       linux_container_options: --security-opt seccomp=unconfined
     do_ci_build: ${{ parameters.do_ci_build }}
@@ -111,7 +111,7 @@ jobs:
 
     container:
 
-      image: ghcr.io/microsoft/mu_devops/ubuntu-24-build:0e384ee
+      image: ghcr.io/microsoft/mu_devops/ubuntu-24-build:76935a3
       options: --user root --name mu_devops_build_container --security-opt seccomp=unconfined
 
     steps:

--- a/.azurepipelines/Ubuntu-GCC5.yml
+++ b/.azurepipelines/Ubuntu-GCC5.yml
@@ -13,7 +13,10 @@
 
 variables:
 - group: architectures-arm64-x86-64
-- group: tool-chain-ubuntu-gcc
+- name: tool_chain_tag
+  value: GCC
+- name: vm_image
+  value: ubuntu-latest
 - group: coverage
 
 extends:

--- a/.github/workflows/clangpdb-ci.yml
+++ b/.github/workflows/clangpdb-ci.yml
@@ -70,7 +70,7 @@ jobs:
     with:
       runner: ubuntu-latest
       setup-cmd: both
-      container: ghcr.io/microsoft/mu_devops/ubuntu-24-build:0e384ee
+      container: ghcr.io/microsoft/mu_devops/ubuntu-24-build:76935a3
       python-version: "3.12"
       package-config: ${{ needs.package-matrix.outputs.matrix }}
 

--- a/.pytool/CISettings.py
+++ b/.pytool/CISettings.py
@@ -4,16 +4,17 @@
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 ##
 import glob
-import os
 import logging
+import os
+
+from edk2toolext import codeql as codeql_helpers
 from edk2toolext.environment import shell_environment
 from edk2toolext.invocables.edk2_ci_build import CiBuildSettingsManager
 from edk2toolext.invocables.edk2_ci_setup import CiSetupSettingsManager
+from edk2toolext.invocables.edk2_pr_eval import PrEvalSettingsManager
 from edk2toolext.invocables.edk2_setup import SetupSettingsManager
 from edk2toolext.invocables.edk2_update import UpdateSettingsManager
-from edk2toolext.invocables.edk2_pr_eval import PrEvalSettingsManager
 from edk2toollib.utility_functions import GetHostInfo
-from edk2toolext import codeql as codeql_helpers
 
 
 class Settings(
@@ -190,13 +191,13 @@ class Settings(
             {
                 "Path": "MU_BASECORE",
                 "Url": "https://github.com/microsoft/mu_basecore.git",
-                "Branch": "release/202511",
+                "Branch": "release/202608",
                 "Recurse": {"CIFile": ".pytool/CISettings.py"}
             },
             {
                 "Path": "Common/MU_PLUS",
                 "Url": "https://github.com/microsoft/mu_plus.git",
-                "Branch": "release/202511"
+                "Branch": "release/202608"
             }
         ]
         return []


### PR DESCRIPTION
## Description

Update submodules to 202608 branches. 

Change Ubuntu GCC5 toolchain to GCC because
upstream has deprecated the GCC5 tool chain.

Use newer ubuntu container containing support for IA32 host based unit tests.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested
Local CI/Booting platform

## Integration Instructions
No integration necessary